### PR TITLE
fix gh40: macos build

### DIFF
--- a/src/client/refresh/vk/header/util.h
+++ b/src/client/refresh/vk/header/util.h
@@ -23,6 +23,9 @@
 #ifndef  __VK_UTIL_H__
 #define  __VK_UTIL_H__
 
+#ifdef __APPLE__
+#define VOLK_VULKAN_H_PATH <MoltenVK/vk_mvk_moltenvk.h>
+#endif
 #include "../volk/volk.h"
 
 typedef struct BufferResource_s {


### PR DESCRIPTION
for the volk part include MoltenVK header instead.