### PR TITLE
network: backport unix workflow to windows.

### DIFF
--- a/src/backends/windows/network.c
+++ b/src/backends/windows/network.c
@@ -391,12 +391,11 @@ NET_StringToSockaddr(const char *s, struct sockaddr_storage *sadr)
 	struct addrinfo hints;
 	struct addrinfo *resultp;
 
-	memset(sadr, 0, sizeof(*sadr));
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_socktype = SOCK_DGRAM;
 	hints.ai_family = PF_UNSPEC;
 
-	strcpy(copy, s);
+	Q_strlcpy(copy, s, sizeof(copy));
 	addrs = space = copy;
 
 	if (*addrs == '[')


### PR DESCRIPTION
removing useless initial memset to sadr since it s done per socket family down the line. using safer Q_strlcpy instead of strcpy for the initial copy.