### PR TITLE
network: log getaddrinfo error on Windows

### DIFF
--- a/src/backends/windows/network.c
+++ b/src/backends/windows/network.c
@@ -840,6 +840,8 @@ NET_IPSocket(char *net_interface, int port, netsrc_t type, int family)
 
 	if ((Error = getaddrinfo(Host, Service, &hints, &res)))
 	{
+		Com_Printf("%s ERROR: getaddrinfo: %s\n",
+				__func__, gai_strerror(Error));
 		return 0;
 	}
 


### PR DESCRIPTION
The Unix network code logs getaddrinfo failures via Com_Printf and gai_strerror, but the Windows side
silently returned 0. Add the same error logging to match the Unix behaviour.