### PR TITLE
common: harden PCX decoding and BSP brush side loading

### DIFF
--- a/src/common/collision.c
+++ b/src/common/collision.c
@@ -1618,7 +1618,7 @@ CMod_LoadBrushSides(const char *name, cbrushside_t **map_brushsides, int *numbru
 		num = in->planenum;
 		j = in->texinfo;
 
-		if (j >= numtexinf || num > numplanes)
+		if (j >= numtexinf || num < 0 || num >= numplanes)
 		{
 			Com_Error(ERR_DROP, "%s: Bad brushside texinfo", __func__);
 			return;

--- a/src/common/models/image.c
+++ b/src/common/models/image.c
@@ -187,7 +187,7 @@ PCX_Decode(const char *name, const byte *raw, int len, byte **pic, byte **palett
 	int *width, int *height, int *bitsPerPixel)
 {
 	const pcx_t *pcx;
-	int full_size;
+	size_t full_size;
 	int pcx_width, pcx_height, bytes_per_line;
 	qboolean image_issues = false;
 	byte *out, *pix;
@@ -229,10 +229,16 @@ PCX_Decode(const char *name, const byte *raw, int len, byte **pic, byte **palett
 		return;
 	}
 
-	full_size = (pcx_height + 1) * (pcx_width + 1);
+	full_size = (size_t)(pcx_height + 1) * (pcx_width + 1);
 	if ((pcx->color_planes == 3 || pcx->color_planes == 4)
 		&& pcx->bits_per_pixel == 8)
 	{
+		if (full_size > SIZE_MAX / 4)
+		{
+			Com_Printf("%s: %s dimensions overflow\n", __func__, name);
+			return;
+		}
+
 		full_size *= 4;
 		*bitsPerPixel = 32;
 	}


### PR DESCRIPTION
Defensive programming hardening for edge cases in file parsing. While game assets are generally trustworthy, these changes guard against potential integer overflow in PCX dimension calculations and signed/unsigned mismatch in BSP brush side plane indices.