### PR TITLE
sound: add optional OpenAL HRTF support

### DIFF
--- a/doc/040_cvarlist.md
+++ b/doc/040_cvarlist.md
@@ -351,6 +351,10 @@ it's `+set busywait 0` (setting the `busywait` cvar) and `-portable`
    wrong one. The given value is the name of the library, for example
    `libopenal.so.1`.
 
+* **al_hrtf**: Enable OpenAL HRTF (Head-Related Transfer Function) for
+  accurate 3D positional audio over headphones. Set to `1` to enable,
+  requires `snd_restart`. Only supported with OpenAL Soft 1.17+.
+
 * **ogg_enable**: Enable Ogg/Vorbis music playback.
 
 * **ogg_ignoretrack0**: Normally Quake II disables the background music

--- a/src/client/sound/qal.c
+++ b/src/client/sound/qal.c
@@ -44,6 +44,7 @@ static ALCcontext *context;
 static ALCdevice *device;
 static cvar_t *al_device;
 static cvar_t *al_driver;
+static cvar_t *al_hrtf;
 static qboolean hasAlcExtDisconnect;
 static void *handle;
 
@@ -599,6 +600,30 @@ QAL_Init()
 	if (qalcIsExtensionPresent(device, "ALC_EXT_disconnect") != AL_FALSE)
 	{
 		hasAlcExtDisconnect = true;
+	}
+
+	al_hrtf = Cvar_Get("al_hrtf", "0", CVAR_ARCHIVE);
+
+	if (qalcIsExtensionPresent(device, "ALC_SOFT_HRTF") != AL_FALSE)
+	{
+		if (al_hrtf->value)
+		{
+			LPALCRESETDEVICESOFT qalcResetDeviceSOFT =
+				(LPALCRESETDEVICESOFT)qalcGetProcAddress(device, "alcResetDeviceSOFT");
+			if (qalcResetDeviceSOFT)
+			{
+				ALCint attrs[] = { ALC_HRTF_SOFT, ALC_TRUE, 0 };
+				if (qalcResetDeviceSOFT(device, attrs))
+				{
+					ALCint hrtf_enabled;
+					qalcGetIntegerv(device, ALC_HRTF_SOFT, 1, &hrtf_enabled);
+					Com_Printf("OpenAL HRTF: %s\n",
+							hrtf_enabled ? "enabled" : "not available");
+				}
+			} else {
+				Com_Printf("OpenAL HRTF unsupported\n");
+			}
+		}
 	}
 
 


### PR DESCRIPTION
HRTF (Head-Related Transfer Function) applies per-ear filtering that simulates how sound waves interact with head and ear geometry, providing accurate 3D positional audio over headphones. Players can better locate enemies, items and ambient sounds by direction and elevation without needing surround speaker setups.

Disabled by default, enable with al_hrtf 1 and snd_restart. Requires OpenAL Soft 1.17+ with ALC_SOFT_HRTF extension.