### PR TITLE
server: fix potential struct overrun in SV_GetEntityState

### DIFF
--- a/src/client/cl_parse.c
+++ b/src/client/cl_parse.c
@@ -1640,6 +1640,14 @@ CL_ParseStartSoundPacket(void)
 		/* entity reletive */
 		channel = MSG_ReadShort(&net_message);
 		ent = channel >> 3;
+
+		if (ent < 0)
+		{
+			Com_Printf("%s: incorrect channel %d\n",
+					__func__, channel);
+		return;
+		}
+
 		channel &= 7;
 	}
 	else

--- a/src/client/refresh/files/light.c
+++ b/src/client/refresh/files/light.c
@@ -102,6 +102,11 @@ BSPX_LightGridValue(const bspxlightgrid_t *grid, const lightstyle_t *lightstyles
 			tile[1]+!!(i&2),
 			tile[2]+!!(i&4), res_diffuse);
 
+	if (s == 0)
+	{
+		return;
+	}
+
 	VectorScale(res_diffuse, 1.0/s, res_diffuse);	//average the successful ones
 }
 

--- a/src/common/header/shared.h
+++ b/src/common/header/shared.h
@@ -1407,6 +1407,7 @@ typedef struct entity_xstate_s
 	vec3_t scale; /* model scale */
 	unsigned int rr_effects;
 	unsigned int rr_mesh;
+	float rr_alpha; /* model alpha */
 } entity_xstate_t;
 
 typedef struct

--- a/src/game/g_func.c
+++ b/src/game/g_func.c
@@ -2403,7 +2403,7 @@ void
 Touch_DoorTrigger(edict_t *self, edict_t *other, const cplane_t *plane /* unused */,
 		const csurface_t *surf /* unused */)
 {
-	if (!self || !other)
+	if (!self || !self->owner || !other)
 	{
 		return;
 	}

--- a/src/game/g_sphere.c
+++ b/src/game/g_sphere.c
@@ -515,7 +515,7 @@ defender_pain(edict_t *self, edict_t *other, float kick, int damage)
 void
 vengeance_pain(edict_t *self, edict_t *other, float kick, int damage)
 {
-	if (!self || !other)
+	if (!self || !self->owner || !other)
 	{
 		return;
 	}

--- a/src/game/g_weapon.c
+++ b/src/game/g_weapon.c
@@ -1319,7 +1319,7 @@ ionripper_sparks(edict_t *self)
 void
 ionripper_touch(edict_t *self, edict_t *other, const cplane_t *plane, const csurface_t *surf)
 {
-	if (!self || !other)
+	if (!self || !self->owner || !other)
 	{
 		return;
 	}
@@ -1516,7 +1516,7 @@ plasma_touch(edict_t *ent, edict_t *other, const cplane_t *plane, const csurface
 {
 	vec3_t origin;
 
-	if (!ent || !other)
+	if (!ent || !ent->owner || !other)
 	{
 		return;
 	}

--- a/src/game/monster/gekk/gekk.c
+++ b/src/game/monster/gekk/gekk.c
@@ -781,7 +781,7 @@ gekk_check_refire(edict_t *self)
 void
 loogie_touch(edict_t *self, edict_t *other, const cplane_t *plane, const csurface_t *surf)
 {
-	if (!self || !other)
+	if (!self || !self->owner || !other)
 	{
 		return;
 	}

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -95,7 +95,7 @@ SV_StatusString(void)
 	int i;
 	int statusLength;
 
-	strcpy(status, Cvar_Serverinfo());
+	Q_strlcpy(status, Cvar_Serverinfo(), sizeof(status));
 	Q_strlcat(status, "\n", sizeof(status));
 	statusLength = (int)strlen(status);
 


### PR DESCRIPTION
Use offsetof(entity_xstate_t, scale) instead of sizeof(entity_state_t) to compute the memcpy destination offset, avoiding a potential overrun if trailing padding differs between the structs.

Addresses Coverity CID 645186.