### PR TITLE
soft: clamp polygon left-edge scan to viewport

### DIFF
--- a/src/client/refresh/soft/sw_poly.c
+++ b/src/client/refresh/soft/sw_poly.c
@@ -774,7 +774,7 @@ R_PolygonScanLeftEdge (espan_t *s_polygon_spans)
 	const emitpoint_t *pvert, *pnext;
 	int i, lmaxindex;
 	espan_t *pspan;
-	float vtop;
+	float vtop, vvert;
 
 	pspan = s_polygon_spans;
 	i = s_minindex;
@@ -785,28 +785,51 @@ R_PolygonScanLeftEdge (espan_t *s_polygon_spans)
 	if (lmaxindex == 0)
 		lmaxindex = r_polydesc.nump;
 
-	vtop = ceil (r_polydesc.pverts[i].v);
+	vvert = r_polydesc.pverts[i].v;
+	if (vvert < r_refdef.fvrecty_adj)
+		vvert = r_refdef.fvrecty_adj;
+	if (vvert > r_refdef.fvrectbottom_adj)
+		vvert = r_refdef.fvrectbottom_adj;
+
+	vtop = ceil (vvert);
 
 	do
 	{
-		float vbottom;
+		float vbottom, vnext;
 
 		pvert = &r_polydesc.pverts[i];
 		pnext = pvert - 1;
+		vnext = pnext->v;
+		if (vnext < r_refdef.fvrecty_adj)
+			vnext = r_refdef.fvrecty_adj;
+		if (vnext > r_refdef.fvrectbottom_adj)
+			vnext = r_refdef.fvrectbottom_adj;
 
-		vbottom = ceil (pnext->v);
+		vbottom = ceil (vnext);
 
 		if (vtop < vbottom)
 		{
 			int v, u, istep, itop, ibottom;
-			float du, dv, u_step;
+			float du, dv, u_step, uvert, unext;
 
-			du = pnext->u - pvert->u;
-			dv = pnext->v - pvert->v;
+			uvert = pvert->u;
+			if (uvert < r_refdef.fvrectx_adj)
+				uvert = r_refdef.fvrectx_adj;
+			if (uvert > r_refdef.fvrectright_adj)
+				uvert = r_refdef.fvrectright_adj;
+
+			unext = pnext->u;
+			if (unext < r_refdef.fvrectx_adj)
+				unext = r_refdef.fvrectx_adj;
+			if (unext > r_refdef.fvrectright_adj)
+				unext = r_refdef.fvrectright_adj;
+
+			du = unext - uvert;
+			dv = vnext - vvert;
 
 			u_step = (du * SHIFT16XYZ_MULT) / dv;
 			// adjust u to ceil the integer portion
-			u = (int)((pvert->u * SHIFT16XYZ_MULT) + u_step * (vtop - pvert->v)) +
+			u = (int)((uvert * SHIFT16XYZ_MULT) + u_step * (vtop - vvert)) +
 				(SHIFT16XYZ_MULT - 1);
 			itop = (int)vtop;
 			ibottom = (int)vbottom;
@@ -822,6 +845,7 @@ R_PolygonScanLeftEdge (espan_t *s_polygon_spans)
 		}
 
 		vtop = vbottom;
+		vvert = vnext;
 
 		i--;
 		if (i == 0)


### PR DESCRIPTION
R_PolygonScanLeftEdge fed raw projected vertex u/v straight into the span list, unlike its counterpart R_PolygonScanRightEdge which already clamps to r_refdef.fvrect*_adj. When a polygon vertex is snapped to NEAR_CLIP its screen-space projection grows unbounded and can come out negative; the resulting negative pspan->u/pspan->v produce an OOB pointer in R_PolygonDrawSpans:

    s_spanletvars.pdest = d_viewbuffer + (vid_buffer_width * pspan->v) + pspan->u;

Mirror the right-edge viewport clamp so the left edge stays within the rendered area. Fixes the water/translucent-surface crash reported upstream as yquake2/yquake2#1173 (R_DrawSpanletTurbulentBlended33 segfault when bobbing on water at higher resolutions).

AI assistance pointed at the general approach of clamping the vertex to viewport limits before feeding it to the span scan; the author is not deeply familiar with the software renderer internals.