### PR TITLE
vk: decouple index buffer allocation from vertex count

### DIFF
--- a/src/client/refresh/files/mesh.c
+++ b/src/client/refresh/files/mesh.c
@@ -287,12 +287,9 @@ R_GenFanIndexes(unsigned short *data, unsigned from, unsigned to)
 	/* fill the index buffer so that we can emulate triangle fans via triangle lists */
 	for (i = from; i < to; i++)
 	{
-		*data = from;
-		data ++;
-		*data = i + 1;
-		data++;
-		*data = i + 2;
-		data ++;
+		*data++ = from;
+		*data++ = i + 1;
+		*data++ = i + 2;
 	}
 }
 

--- a/src/client/refresh/vk/header/local.h
+++ b/src/client/refresh/vk/header/local.h
@@ -304,6 +304,7 @@ extern uint16_t	*vertIdxData;
 void	Mesh_Init (void);
 void	Mesh_Free (void);
 int Mesh_VertsRealloc(int count);
+int Mesh_IndexesRealloc(int count);
 
 void Mod_Init(void);
 

--- a/src/client/refresh/vk/vk_light.c
+++ b/src/client/refresh/vk/vk_light.c
@@ -97,8 +97,8 @@ R_RenderDlights(void)
 		}
 	}
 
-	Mesh_VertsRealloc(64);
-	R_GenFanIndexes(vertIdxData, 0, 48);
+	Mesh_IndexesRealloc(48);
+	R_GenFanIndexes(vertIdxData, 0, 16);
 	ibuffer = UpdateIndexBuffer(vertIdxData, 48 * sizeof(uint16_t), &dstOffset);
 
 	vkCmdBindVertexBuffers(vk_activeCmdbuffer, 0, 1, &vbo, &vboOffset);

--- a/src/client/refresh/vk/vk_main.c
+++ b/src/client/refresh/vk/vk_main.c
@@ -254,7 +254,7 @@ R_DrawNullModel(entity_t *currententity)
 	memcpy(vertData, verts, sizeof(verts));
 	memcpy(uboData,  model, sizeof(model));
 
-	Mesh_VertsRealloc(24);
+	Mesh_IndexesRealloc(24);
 	R_GenFanIndexes(vertIdxData, 0, 4);
 	R_GenFanIndexes(vertIdxData + 4 * 3, 6, 10);
 	buffer = UpdateIndexBuffer(vertIdxData, 24 * sizeof(uint16_t), &dstOffset);

--- a/src/client/refresh/vk/vk_mesh.c
+++ b/src/client/refresh/vk/vk_mesh.c
@@ -44,6 +44,7 @@ static	vec3_t	*shadowverts = NULL;
 uint16_t	*vertIdxData = NULL;
 
 static	int	verts_count = 0;
+static	int	index_count = 0;
 
 // correction matrix with "hacked depth" for models with RF_DEPTHHACK flag set
 static float r_vulkan_correction_dh[16] = {
@@ -52,6 +53,30 @@ static float r_vulkan_correction_dh[16] = {
 	0.f,  0.f, .3f, 0.f,
 	0.f,  0.f, .3f, 1.f
 };
+
+int
+Mesh_IndexesRealloc(int count)
+{
+	void *ptr;
+
+	if (index_count > count)
+	{
+		return 0;
+	}
+
+	index_count = ROUNDUP(count * 2, 256);
+
+	ptr = realloc(vertIdxData, index_count * sizeof(uint16_t));
+	YQ2_COM_CHECK_OOM(ptr, "realloc()",
+					index_count * sizeof(uint16_t))
+	if (!ptr)
+	{
+		return -1;
+	}
+	vertIdxData = ptr;
+
+	return 0;
+}
 
 int
 Mesh_VertsRealloc(int count)
@@ -92,15 +117,6 @@ Mesh_VertsRealloc(int count)
 	}
 	vertList = ptr;
 
-	ptr = realloc(vertIdxData, verts_count * sizeof(uint16_t));
-	YQ2_COM_CHECK_OOM(ptr, "realloc()",
-					verts_count * sizeof(uint16_t))
-	if (!ptr)
-	{
-		return -1;
-	}
-	vertIdxData = ptr;
-
 	return 0;
 }
 
@@ -117,8 +133,14 @@ Mesh_Init(void)
 	vertList = NULL;
 
 	verts_count = 0;
+	index_count = 0;
 
 	if (Mesh_VertsRealloc(MAX_VERTS))
+	{
+		Com_Error(ERR_FATAL, "%s: can't allocate memory", __func__);
+	}
+
+	if (Mesh_IndexesRealloc(MAX_VERTS * 3))
 	{
 		Com_Error(ERR_FATAL, "%s: can't allocate memory", __func__);
 	}
@@ -138,6 +160,7 @@ Mesh_Free(void)
 			__func__, verts_count);
 	}
 	verts_count = 0;
+	index_count = 0;
 
 	if (shadowverts)
 	{
@@ -279,6 +302,12 @@ Vk_DrawAliasFrameLerpCommands(int *order, const int *order_end, float alpha,
 			while (--count);
 		}
 
+		if (Mesh_IndexesRealloc(*index_pos + (vertexCount - 2) * 3))
+		{
+			Com_Error(ERR_FATAL, "%s: can't allocate memory", __func__);
+			return;
+		}
+
 		if (pipelineIdx == TRIANGLE_STRIP)
 		{
 			R_GenStripIndexes(vertIdxData + *index_pos,
@@ -418,7 +447,7 @@ Vk_DrawAliasFrameLerp(entity_t *currententity, dmdx_t *paliashdr, float backlerp
 		descriptorSets, 1, &uboOffset);
 	vkCmdBindVertexBuffers(vk_activeCmdbuffer, 0, 1, &vbo, &vboOffset);
 
-	*buffer = UpdateIndexBuffer(vertIdxData, verts_count * sizeof(uint16_t), dstOffset);
+	*buffer = UpdateIndexBuffer(vertIdxData, *index_pos * sizeof(uint16_t), dstOffset);
 
 	vkCmdBindIndexBuffer(vk_activeCmdbuffer, **buffer, *dstOffset, VK_INDEX_TYPE_UINT16);
 	vkCmdDrawIndexed(vk_activeCmdbuffer, *index_pos, 1, 0, 0, 0);

--- a/src/client/refresh/vk/vk_surf.c
+++ b/src/client/refresh/vk/vk_surf.c
@@ -77,7 +77,7 @@ DrawVkPoly(const msurface_t *fa, image_t *texture, const float *color)
 	vkCmdPushConstants(vk_activeCmdbuffer, vk_drawTexQuadPipeline[vk_state.current_renderpass].layout,
 		VK_SHADER_STAGE_FRAGMENT_BIT, PUSH_CONSTANT_VERTEX_SIZE * sizeof(float), sizeof(gamma), &gamma);
 
-	Mesh_VertsRealloc((p->numverts - 2) * 3);
+	Mesh_IndexesRealloc((p->numverts - 2) * 3);
 	R_GenFanIndexes(vertIdxData, 0, p->numverts - 2);
 	buffer = UpdateIndexBuffer(vertIdxData, (p->numverts - 2) * 3 * sizeof(uint16_t), &dstOffset);
 
@@ -462,6 +462,13 @@ dynamic:
 					return;
 				}
 
+				if (Mesh_IndexesRealloc(index_pos + (nv - 2) * 3))
+				{
+					Com_Error(ERR_FATAL, "%s: can't allocate memory",
+							__func__);
+					return;
+				}
+
 				memcpy(verts_buffer + pos_vect, p->verts,
 						sizeof(mvtx_t) * nv);
 				for (int j = 0; j < nv; j++)
@@ -624,7 +631,7 @@ Vk_RenderLightmappedPoly(msurface_t *surf, float alpha,
 
 	for (p = surf->polys; p; p = p->chain)
 	{
-		if (Mesh_VertsRealloc(pos_vect + nv))
+		if (Mesh_IndexesRealloc(index_pos + (nv - 2) * 3))
 		{
 			Com_Error(ERR_FATAL, "%s: can't allocate memory", __func__);
 			return;

--- a/src/client/refresh/vk/vk_warp.c
+++ b/src/client/refresh/vk/vk_warp.c
@@ -128,10 +128,14 @@ EmitWaterPolys(const msurface_t *fa, image_t *texture, const float *modelMatrix,
 			descriptorSets, 1, &uboOffset);
 	}
 
+	int total_indices = 0;
 	for (bp = fa->polys; bp; bp = bp->next)
+	{
 		total_verts += bp->numverts;
+		total_indices += (bp->numverts - 2) * 3;
+	}
 
-	if (Mesh_VertsRealloc(total_verts))
+	if (Mesh_IndexesRealloc(total_indices))
 	{
 		Com_Error(ERR_FATAL, "%s: can't allocate memory", __func__);
 		return;
@@ -217,8 +221,8 @@ R_DrawSkyBox(void)
 	uboData = QVk_GetUniformBuffer(sizeof(model), &uboOffset, &uboDescriptorSet);
 	memcpy(uboData, model, sizeof(model));
 
-	Mesh_VertsRealloc(6);
-	R_GenFanIndexes(vertIdxData, 0, 4);
+	Mesh_IndexesRealloc(6);
+	R_GenFanIndexes(vertIdxData, 0, 2);
 	buffer = UpdateIndexBuffer(vertIdxData, 6 * sizeof(uint16_t), &dstOffset);
 	gamma = 2.1F - vid_gamma->value;
 


### PR DESCRIPTION
The index buffer was piggybacking on the vertex allocator, sized to the vertex count. That works as long as polys stay triangles, but fan triangulation emits 3*(nv - 2) indices per polygon, so anything with more than 3 verts needs more index room than vertex room. Remaster maps like mguhub finally tipped it over; ASAN caught a heap overflow opening doors there.

Give indices their own allocator and counter, and make each caller request the index capacity it actually needs. Also fix the alias model upload, which was sending verts_count bytes instead of what was actually written, and two helpers (dlight circle, skybox quad) that were writing three times more indices than they uploaded; those stayed in bounds only thanks to the old oversized allocator.