### PR TITLE
refresh: compute surface extents in long double precision

### DIFF
--- a/src/client/refresh/files/maps.c
+++ b/src/client/refresh/files/maps.c
@@ -346,12 +346,12 @@ Mod_CalcSurfaceExtents(const int *surfedges, int numsurfedges, mvertex_t *vertex
 
 		for (j = 0; j < 2; j++)
 		{
-			float val;
+			long double val;
 
-			val = (double)v->position[0] * tex->vecs[j][0] +
-				  (double)v->position[1] * tex->vecs[j][1] +
-				  (double)v->position[2] * tex->vecs[j][2] +
-				  (double)tex->vecs[j][3];
+			val = (long double)v->position[0] * tex->vecs[j][0] +
+				  (long double)v->position[1] * tex->vecs[j][1] +
+				  (long double)v->position[2] * tex->vecs[j][2] +
+				  (long double)tex->vecs[j][3];
 
 			if (val < mins[j])
 			{


### PR DESCRIPTION
Mod_CalcSurfaceExtents projected each vertex onto the texture vectors in double precision and stored the result in a float, which produced slightly different rounding under SSE vs the legacy x87 path. Surfaces whose texture coordinates were not aligned on integer boundaries could end up with bmins/bmaxs off by one block, leaving visible lightmap stripes on the affected polygons.

Promote the per-vertex computation and accumulator to long double so the multiply-add chain runs in 80-bit precision regardless of which FP backend the compiler picks; mins/maxs stay double, so the floor and ceil downstream are unaffected. This matches the fix the Quake 1 community has been carrying for years and the one applied to q2pro.

Reported upstream as yquake2/yquake2#886. AI assistance pointed at the long-double cast as the established cross-engine remedy; the author is not deeply familiar with the GL* renderer model loaders that ultimately consume these extents.