### PR TITLE
vk: fix screenshot readback image index and drop stray device-wait

### DIFF
--- a/src/client/refresh/vk/header/qvk.h
+++ b/src/client/refresh/vk/header/qvk.h
@@ -272,6 +272,8 @@ extern qboolean vk_frameStarted;
 extern qboolean vk_recreateSwapchainNeeded;
 // is QVk initialized?
 extern qboolean vk_initialized;
+// index of the currently acquired swapchain image.
+extern uint32_t vk_imageIndex;
 
 // function pointers
 extern PFN_vkCreateDebugUtilsMessengerEXT qvkCreateDebugUtilsMessengerEXT;

--- a/src/client/refresh/vk/vk_common.c
+++ b/src/client/refresh/vk/vk_common.c
@@ -121,7 +121,7 @@ VkCommandBuffer vk_activeCmdbuffer = VK_NULL_HANDLE;
 // index of active command buffer
 int vk_activeBufferIdx = 0;
 // index of currently acquired image
-static uint32_t vk_imageIndex = 0;
+uint32_t vk_imageIndex = 0;
 // index of currently used image semaphore
 uint32_t vk_imageSemaphoreIdx = 0;
 // index of currently used staging buffer

--- a/src/client/refresh/vk/vk_image.c
+++ b/src/client/refresh/vk/vk_image.c
@@ -571,7 +571,7 @@ QVk_ReadPixels(uint8_t *dstBuffer, const VkOffset2D *offset, const VkExtent2D *e
 		.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
 		.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
 		.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-		.image = vk_swapchain.images[vk_activeBufferIdx],
+		.image = vk_swapchain.images[vk_imageIndex],
 		.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
 		.subresourceRange.baseMipLevel = 0,
 		.subresourceRange.baseArrayLayer = 0,
@@ -594,8 +594,7 @@ QVk_ReadPixels(uint8_t *dstBuffer, const VkOffset2D *offset, const VkExtent2D *e
 	};
 
 	// copy the swapchain image
-	vkCmdCopyImageToBuffer(cmdBuffer, vk_swapchain.images[vk_activeBufferIdx], VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, buff.buffer, 1, &region);
-	VK_VERIFY(vkDeviceWaitIdle(vk_device.logical));
+	vkCmdCopyImageToBuffer(cmdBuffer, vk_swapchain.images[vk_imageIndex], VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, buff.buffer, 1, &region);
 	QVk_SubmitCommand(&cmdBuffer, &vk_device.gfxQueue);
 
 	// store image in destination buffer


### PR DESCRIPTION
QVk_ReadPixels was picking the swapchain image with vk_activeBufferIdx, which tracks command-buffer rotation — unrelated to the acquired image, and off entirely when the swapchain has more images than command buffers. Use vk_imageIndex instead and expose it via qvk.h.

While here, drop the pre-submit vkDeviceWaitIdle: gfxQueue in-order execution already serialises the copy after the present, and QVk_SubmitCommand's fence handles the CPU wait before the map.