### PR TITLE
vk: don't swallow swapchain/staging buffer error returns

### DIFF
--- a/src/client/refresh/vk/vk_common.c
+++ b/src/client/refresh/vk/vk_common.c
@@ -1129,10 +1129,14 @@ CreateStagingBuffer(VkDeviceSize size, qvkstagingbuffer_t *dstBuffer, int i)
 		.flags = 0
 	};
 
-	VK_VERIFY(QVk_CreateStagingBuffer(size,
+	if (QVk_CreateStagingBuffer(size,
 		dstBuffer,
 		VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-		VK_MEMORY_PROPERTY_HOST_CACHED_BIT));
+		VK_MEMORY_PROPERTY_HOST_CACHED_BIT) != VK_SUCCESS)
+	{
+		return;
+	}
+
 	dstBuffer->pMappedData = buffer_map(&dstBuffer->resource);
 	dstBuffer->submitted = false;
 
@@ -2246,7 +2250,7 @@ QVk_BeginFrame(const VkViewport* viewport, const VkRect2D* scissor)
 	VK_VERIFY(buffer_invalidate(&vk_dynVertexBuffers[vk_activeDynBufferIdx].resource));
 	VK_VERIFY(buffer_invalidate(&vk_dynIndexBuffers[vk_activeDynBufferIdx].resource));
 
-	VK_VERIFY(vkWaitForFences(vk_device.logical, 1, &vk_fences[vk_activeBufferIdx], VK_TRUE, UINT32_MAX));
+	VK_VERIFY(vkWaitForFences(vk_device.logical, 1, &vk_fences[vk_activeBufferIdx], VK_TRUE, UINT64_MAX));
 	VK_VERIFY(vkResetFences(vk_device.logical, 1, &vk_fences[vk_activeBufferIdx]));
 
 	// setup command buffers and render pass for drawing

--- a/src/client/refresh/vk/vk_swapchain.c
+++ b/src/client/refresh/vk/vk_swapchain.c
@@ -146,6 +146,7 @@ VkResult QVk_CreateSwapchain()
 	VkSurfaceFormatKHR *surfaceFormats = NULL;
 	VkPresentModeKHR *presentModes = NULL;
 	uint32_t formatCount, presentModesCount;
+	VkResult res;
 	VkImage *tmp;
 
 	VK_VERIFY(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vk_device.physical, vk_surface, &surfaceCaps));
@@ -155,13 +156,39 @@ VkResult QVk_CreateSwapchain()
 	if (formatCount > 0)
 	{
 		surfaceFormats = (VkSurfaceFormatKHR *)malloc(formatCount * sizeof(VkSurfaceFormatKHR));
-		VK_VERIFY(vkGetPhysicalDeviceSurfaceFormatsKHR(vk_device.physical, vk_surface, &formatCount, surfaceFormats));
+
+		if (!surfaceFormats)
+		{
+			return VK_ERROR_OUT_OF_DEVICE_MEMORY;
+		}
+
+		res = vkGetPhysicalDeviceSurfaceFormatsKHR(vk_device.physical, vk_surface, &formatCount, surfaceFormats);
+
+		if (res != VK_SUCCESS)
+		{
+			free(surfaceFormats);
+			return res;
+		}
 	}
 
 	if (presentModesCount > 0)
 	{
 		presentModes = (VkPresentModeKHR *)malloc(presentModesCount * sizeof(VkPresentModeKHR));
-		VK_VERIFY(vkGetPhysicalDeviceSurfacePresentModesKHR(vk_device.physical, vk_surface, &presentModesCount, presentModes));
+
+		if (!presentModes)
+		{
+			free(surfaceFormats);
+			return VK_ERROR_OUT_OF_DEVICE_MEMORY;
+		}
+
+		res = vkGetPhysicalDeviceSurfacePresentModesKHR(vk_device.physical, vk_surface, &presentModesCount, presentModes);
+
+		if (res != VK_SUCCESS)
+		{
+			free(surfaceFormats);
+			free(presentModes);
+			return res;
+		}
 
 		Com_Printf("Supported present modes: ");
 		for (int i = 0; i < presentModesCount; i++)
@@ -240,7 +267,7 @@ VkResult QVk_CreateSwapchain()
 	Com_Printf("...trying swapchain extent: %dx%d\n", vk_swapchain.extent.width, vk_swapchain.extent.height);
 	Com_Printf("...trying swapchain image format: %d\n", vk_swapchain.format);
 
-	VkResult res = vkCreateSwapchainKHR(vk_device.logical, &scCreateInfo, NULL, &vk_swapchain.sc);
+	res = vkCreateSwapchainKHR(vk_device.logical, &scCreateInfo, NULL, &vk_swapchain.sc);
 	if (res != VK_SUCCESS)
 	{
 		return res;


### PR DESCRIPTION
VK_VERIFY only prints; on failure execution continued with uninitialised resources. Capture results explicitly and bail. Also bump the BeginFrame fence wait to UINT64_MAX to match the other call sites.