### PR TITLE
network: avoid uninitialized sockaddr on recvfrom error

### DIFF
--- a/src/backends/unix/network.c
+++ b/src/backends/unix/network.c
@@ -182,6 +182,10 @@ SockadrToNetadr(struct sockaddr_storage *s, netadr_t *a)
 			a->scope_id = s6->sin6_scope_id;
 		}
 	}
+	else
+	{
+		memset(a, 0, sizeof(*a));
+	}
 }
 
 void
@@ -547,6 +551,7 @@ NET_GetPacket(netsrc_t sock, netadr_t *net_from, sizebuf_t *net_message)
 		}
 
 		fromlen = sizeof(from);
+		memset(&from, 0, fromlen);
 		ret = recvfrom(net_socket, net_message->data, net_message->maxsize,
 				0, (struct sockaddr *)&from, &fromlen);
 

--- a/src/backends/windows/network.c
+++ b/src/backends/windows/network.c
@@ -181,6 +181,10 @@ SockadrToNetadr(struct sockaddr_storage *s, netadr_t *a)
 			a->scope_id = s6->sin6_scope_id;
 		}
 	}
+	else
+	{
+		memset(a, 0, sizeof(*a));
+	}
 }
 
 qboolean
@@ -571,6 +575,7 @@ NET_GetPacket(netsrc_t sock, netadr_t *net_from, sizebuf_t *net_message)
 		}
 
 		fromlen = sizeof(from);
+		memset(&from, 0, fromlen);
 		ret = recvfrom(net_socket, (char *)net_message->data,
 				net_message->maxsize, 0, (struct sockaddr *)&from,
 				&fromlen);


### PR DESCRIPTION
recvfrom does not populate the address-out buffer on most error paths, so SockadrToNetadr was reading an indeterminate ss_family and either copying garbage or silently leaving *net_from stale. Zero-init `from` before each recvfrom and add an unknown-family branch in SockadrToNetadr that wildcards *a. Windows WSAEMSGSIZE keeps a real peer in the log since the kernel fills `from` there.