### PR TITLE
server: SV_Multicast underwater hoist and client input bounds checks

### DIFF
--- a/src/server/sv_send.c
+++ b/src/server/sv_send.c
@@ -141,8 +141,8 @@ SV_BroadcastCommand(const char *fmt, ...)
  * MULTICAST_PHS	send to clients potentially hearable from org
  */
 static qboolean
-SV_WereConnected(int cluster, int area2, const vec3_t origin,
-		 const byte *mask, int area1, size_t mask_size)
+SV_WereConnected(int cluster, int area2, const byte *mask, int area1,
+		 size_t mask_size, qboolean underwater, int water_cluster, int water_area)
 {
 	if (cluster >= 0 && ((cluster >> 3) < mask_size) &&
 	    (mask[cluster >> 3] & (1 << (cluster & 7))))
@@ -153,24 +153,12 @@ SV_WereConnected(int cluster, int area2, const vec3_t origin,
 		}
 	}
 
-	/* underwater retry stays dynamic */
-	if (CM_PointContents(origin, 0) & MASK_WATER)
+	if (underwater && water_cluster >= 0 && ((water_cluster >> 3) < mask_size) &&
+	    (mask[water_cluster >> 3] & (1 << (water_cluster & 7))))
 	{
-		vec3_t origin2;
-		int leafnum2, cluster2;
-
-		VectorCopy(origin, origin2);
-		origin2[2] += 32.0f;
-		leafnum2 = CM_PointLeafnum(origin2);
-		cluster2 = CM_LeafCluster(leafnum2);
-
-		if (cluster2 >= 0 && ((cluster2 >> 3) < mask_size) &&
-		    (mask[cluster2 >> 3] & (1 << (cluster2 & 7))))
+		if (CM_AreasConnected(area1, water_area))
 		{
-			if (CM_AreasConnected(area1, CM_LeafArea(leafnum2)))
-			{
-				return true;
-			}
+			return true;
 		}
 	}
 
@@ -199,8 +187,8 @@ SV_GetClientLeafCache(client_t *client, int *area, int *cluster)
 void
 SV_Multicast(const vec3_t origin, multicast_t to)
 {
-	int leafnum, cluster, area1 = 0, j;
-	qboolean reliable;
+	int leafnum = 0, cluster, area1 = 0, water_area = 0, water_cluster = -1, j;
+	qboolean reliable, underwater = false;
 	client_t *client;
 	const byte *mask;
 	size_t mask_size = 0;
@@ -230,7 +218,6 @@ SV_Multicast(const vec3_t origin, multicast_t to)
 		case MULTICAST_PHS_R:
 			reliable = true; /* intentional fallthrough */
 		case MULTICAST_PHS:
-			leafnum = CM_PointLeafnum(origin);
 			cluster = CM_LeafCluster(leafnum);
 			mask = CM_ClusterPHS(cluster, &mask_size);
 			break;
@@ -238,7 +225,6 @@ SV_Multicast(const vec3_t origin, multicast_t to)
 		case MULTICAST_PVS_R:
 			reliable = true; /* intentional fallthrough */
 		case MULTICAST_PVS:
-			leafnum = CM_PointLeafnum(origin);
 			cluster = CM_LeafCluster(leafnum);
 			mask = CM_ClusterPVS(cluster, &mask_size);
 			break;
@@ -247,6 +233,19 @@ SV_Multicast(const vec3_t origin, multicast_t to)
 			mask = NULL;
 			Com_Error(ERR_FATAL, "%s: bad to:%i", __func__, to);
 			return;
+	}
+
+	if (mask && (CM_PointContents(origin, 0) & MASK_WATER))
+	{
+		vec3_t origin2;
+		int water_leafnum;
+
+		VectorCopy(origin, origin2);
+		origin2[2] += 32.0f;
+		water_leafnum = CM_PointLeafnum(origin2);
+		water_cluster = CM_LeafCluster(water_leafnum);
+		water_area = CM_LeafArea(water_leafnum);
+		underwater = true;
 	}
 
 	/* send the data to all relevent clients */
@@ -267,7 +266,7 @@ SV_Multicast(const vec3_t origin, multicast_t to)
 			int area2, cluster2;
 			SV_GetClientLeafCache(client, &area2, &cluster2);
 
-			if (!SV_WereConnected(cluster2, area2, CL_EDICT(client)->s.origin, mask, area1, mask_size))
+			if (!SV_WereConnected(cluster2, area2, mask, area1, mask_size, underwater, water_cluster, water_area))
 			{
 				continue;
 			}

--- a/src/server/sv_user.c
+++ b/src/server/sv_user.c
@@ -450,6 +450,10 @@ SV_BeginDownload_f(void)
 	if (Cmd_Argc() > 2)
 	{
 		offset = (int)strtol(Cmd_Argv(2), (char **)NULL, 10); /* downloaded offset */
+		if (offset < 0)
+		{
+			offset = 0;
+		}
 	}
 
 	/* hacked by zoid to allow more conrol over download
@@ -704,6 +708,14 @@ SV_ExecuteClientMessage(client_t *cl)
 				checksumIndex = net_message.readcount;
 				checksum = MSG_ReadByte(&net_message);
 				lastframe = MSG_ReadLong(&net_message);
+
+				/* impossible ack — would underflow into a stale delta slot */
+				if (lastframe > (int)sv.framenum)
+				{
+					Com_Printf("SV_ReadClientMessage: lastframe out of range\n");
+					SV_DropClient(cl);
+					return;
+				}
 
 				if (lastframe != cl->lastframe)
 				{


### PR DESCRIPTION
SV_Multicast: compute the underwater secondary cluster/area once per call rather than per receiver inside SV_WereConnected. Inputs depend only on the sender origin; combined with the per-client leaf cache (e00fabce), an underwater multicast drops from N x 4 BSP queries to 4.

SV_BeginDownload_f: clamp negative client download offsets to zero. Otherwise they slipped past the > downloadsize check, made SV_NextDownload_f read before the FS buffer, and shipped heap bytes back to the client.

SV_ExecuteClientMessage: drop a client whose lastframe ack exceeds sv.framenum. Otherwise the signed sv.framenum - lastframe underflows in SV_WriteFrameToClient, the >= (UPDATE_BACKUP - 3) test fails, and the frame deltas against a stale slot.