### PR TITLE
common: cache last decompressed PVS/PHS row by cluster

### DIFF
--- a/src/common/collision.c
+++ b/src/common/collision.c
@@ -132,6 +132,9 @@ static byte *pvsrow = NULL;
 static byte *phsrow = NULL;
 static byte *ptsrow = NULL;
 static size_t pxsrow_len = 0;
+// -2: nothing is cached
+static int cached_pvs_cluster = -2;
+static int cached_phs_cluster = -2;
 static cbrush_t *box_brush;
 static cleaf_t *box_leaf;
 static cplane_t *box_planes = NULL;
@@ -1834,6 +1837,8 @@ CM_ModFreeAll(void)
 	}
 
 	pxsrow_len = 0;
+	cached_pvs_cluster = -2;
+	cached_phs_cluster = -2;
 
 	Com_Printf("Server models free up\n");
 }
@@ -1981,6 +1986,9 @@ CM_LoadCachedMap(const char *name, model_t *mod)
 		}
 
 		ptsrow = tmp;
+
+		cached_pvs_cluster = -2;
+		cached_phs_cluster = -2;
 
 		Com_Printf("Allocated " YQ2_COM_PRIdS " bit leafs of PVS/PHS buffer\n",
 			pxsrow_len);
@@ -2240,15 +2248,29 @@ CM_Cluster(int cluster, int type, byte *buffer, size_t size)
 const byte *
 CM_ClusterPVS(int cluster, size_t *size)
 {
+	const byte *result;
 	*size = pxsrow_len / 8;
-	return CM_Cluster(cluster, DVIS_PVS, pvsrow, *size);
+	if (cluster == cached_pvs_cluster)
+	{
+		return pvsrow;
+	}
+	result = CM_Cluster(cluster, DVIS_PVS, pvsrow, *size);
+	cached_pvs_cluster = cluster;
+	return result;
 }
 
 const byte *
 CM_ClusterPHS(int cluster, size_t *size)
 {
+	const byte *result;
 	*size = pxsrow_len / 8;
-	return CM_Cluster(cluster, DVIS_PHS, phsrow, *size);
+	if (cluster == cached_phs_cluster)
+	{
+		return phsrow;
+	}
+	result = CM_Cluster(cluster, DVIS_PHS, phsrow, *size);
+	cached_phs_cluster = cluster;
+	return result;
 }
 
 byte *


### PR DESCRIPTION
Mod_DecompressVis was rerun on every CM_ClusterPVS/CM_ClusterPHS call, even when the cluster matched the previous one. Skip the work when the requested cluster matches the last cached one; invalidate on row realloc and CM_ModFreeAll.