### PR TITLE
vk: add vk_zfix to suppress brush-model z-fighting

### DIFF
--- a/src/client/refresh/vk/header/local.h
+++ b/src/client/refresh/vk/header/local.h
@@ -113,6 +113,7 @@ extern  cvar_t  *vk_molten_fastmath;
 extern  cvar_t  *vk_molten_metalbuffers;
 #endif
 extern	cvar_t	*vk_pixel_size;
+extern  cvar_t  *vk_zfix;
 
 extern	int		c_visible_lightmaps;
 extern	int		c_visible_textures;

--- a/src/client/refresh/vk/header/qvk.h
+++ b/src/client/refresh/vk/header/qvk.h
@@ -172,6 +172,7 @@ typedef struct
 	VkPipelineColorBlendAttachmentState blendOpts;
 	VkBool32 depthTestEnable;
 	VkBool32 depthWriteEnable;
+	VkBool32 depthBiasEnable;
 } qvkpipeline_t;
 
 // Vulkan shader
@@ -198,7 +199,8 @@ typedef struct
 		.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT \
 	}, \
 	.depthTestEnable = VK_TRUE, \
-	.depthWriteEnable = VK_TRUE \
+	.depthWriteEnable = VK_TRUE, \
+	.depthBiasEnable = VK_FALSE \
 }
 
 // renderpass type

--- a/src/client/refresh/vk/vk_common.c
+++ b/src/client/refresh/vk/vk_common.c
@@ -1436,6 +1436,7 @@ CreatePipelines(void)
 	VK_LOAD_VERTFRAG_SHADERS(shaders, polygon, basic);
 	vk_drawPolyPipeline.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 	vk_drawPolyPipeline.blendOpts.blendEnable = VK_TRUE;
+	vk_drawPolyPipeline.depthBiasEnable = VK_TRUE;
 	QVk_CreatePipeline(samplerUboDsLayouts, 2, &vertInfoMEM_VERTEX_T, &vk_drawPolyPipeline, &vk_renderpasses[RP_WORLD], shaders, 2);
 	QVk_DebugSetObjectName((uint64_t)vk_drawPolyPipeline.layout, VK_OBJECT_TYPE_PIPELINE_LAYOUT, "Pipeline Layout: polygon");
 	QVk_DebugSetObjectName((uint64_t)vk_drawPolyPipeline.pl, VK_OBJECT_TYPE_PIPELINE, "Pipeline: polygon");
@@ -1443,6 +1444,7 @@ CreatePipelines(void)
 	// draw lightmapped polygon
 	VK_LOAD_VERTFRAG_SHADERS(shaders, polygon_lmap, polygon_lmap);
 	vk_drawPolyLmapPipeline.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+	vk_drawPolyLmapPipeline.depthBiasEnable = VK_TRUE;
 	QVk_CreatePipeline(samplerUboLmapDsLayouts, 3, &vertInfoMEM_VERTEX_T,
 		&vk_drawPolyLmapPipeline, &vk_renderpasses[RP_WORLD], shaders, 2);
 	QVk_DebugSetObjectName((uint64_t)vk_drawPolyLmapPipeline.layout, VK_OBJECT_TYPE_PIPELINE_LAYOUT, "Pipeline Layout: lightmapped polygon");

--- a/src/client/refresh/vk/vk_main.c
+++ b/src/client/refresh/vk/vk_main.c
@@ -94,6 +94,7 @@ cvar_t	*vk_lmaptexturemode;
 cvar_t	*vk_mip_nearfilter;
 cvar_t	*vk_sampleshading;
 cvar_t	*vk_device_idx;
+cvar_t	*vk_zfix;
 static cvar_t	*vk_underwater;
 
 #if defined(__APPLE__)
@@ -1083,6 +1084,7 @@ R_Register(void)
 	vk_custom_particles = ri.Cvar_Get("vk_custom_particles", "1", CVAR_ARCHIVE);
 	vk_postprocess = ri.Cvar_Get("vk_postprocess", "1", CVAR_ARCHIVE);
 	vk_texturemode = ri.Cvar_Get("vk_texturemode", "VK_MIPMAP_LINEAR", CVAR_ARCHIVE);
+	vk_zfix = ri.Cvar_Get("vk_zfix", "0", CVAR_ARCHIVE);
 	vk_lmaptexturemode = ri.Cvar_Get("vk_lmaptexturemode", "VK_MIPMAP_LINEAR", CVAR_ARCHIVE);
 	vk_mip_nearfilter = ri.Cvar_Get("vk_mip_nearfilter", "0", CVAR_ARCHIVE);
 	vk_sampleshading = ri.Cvar_Get("vk_sampleshading", "1", CVAR_ARCHIVE);
@@ -1310,7 +1312,10 @@ RE_BeginFrame(float camera_separation)
 	}
 
 	if (QVk_BeginFrame(&vk_viewport, &vk_scissor) == VK_SUCCESS)
+	{
 		QVk_BeginRenderpass(RP_WORLD);
+		vkCmdSetDepthBias(vk_activeCmdbuffer, 0.0f, 0.0f, 0.0f);
+	}
 }
 
 /*

--- a/src/client/refresh/vk/vk_pipeline.c
+++ b/src/client/refresh/vk/vk_pipeline.c
@@ -114,7 +114,7 @@ void QVk_CreatePipeline(const VkDescriptorSetLayout *descriptorLayout,
 		.polygonMode = VK_POLYGON_MODE_FILL,
 		.cullMode = pipeline->cullMode,
 		.frontFace = VK_FRONT_FACE_CLOCKWISE,
-		.depthBiasEnable = VK_FALSE,
+		.depthBiasEnable = pipeline->depthBiasEnable,
 		.depthBiasConstantFactor = 0.f,
 		.depthBiasClamp = 0.f,
 		.depthBiasSlopeFactor = 0.f,
@@ -162,12 +162,12 @@ void QVk_CreatePipeline(const VkDescriptorSetLayout *descriptorLayout,
 		.blendConstants[3] = 0.f
 	};
 
-	VkDynamicState dynamicStates[] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
+	VkDynamicState dynamicStates[] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR, VK_DYNAMIC_STATE_DEPTH_BIAS };
 	VkPipelineDynamicStateCreateInfo dsCreateInfo = {
 		.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO,
 		.pNext = NULL,
 		.flags = 0,
-		.dynamicStateCount = 2,
+		.dynamicStateCount = 3,
 		.pDynamicStates = dynamicStates
 	};
 

--- a/src/client/refresh/vk/vk_surf.c
+++ b/src/client/refresh/vk/vk_surf.c
@@ -713,7 +713,8 @@ R_DrawInlineBModel(const entity_t *currententity, const model_t *currentmodel,
 	VkDescriptorSet uboDescriptorSet;
 	uint8_t *uboData = QVk_GetUniformBuffer(sizeof(lmapPolyUbo), &uboOffset, &uboDescriptorSet);
 	memcpy(uboData, &lmapPolyUbo, sizeof(lmapPolyUbo));
-
+	if (vk_zfix->value)
+		vkCmdSetDepthBias(vk_activeCmdbuffer, 1.0f, 0.0f, 0.05f);
 	QVk_BindPipeline(&vk_drawPolyLmapPipeline);
 	vkCmdBindDescriptorSets(vk_activeCmdbuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
 		vk_drawPolyLmapPipeline.layout, 1, 1, &uboDescriptorSet, 1, &uboOffset);
@@ -750,6 +751,8 @@ R_DrawInlineBModel(const entity_t *currententity, const model_t *currentmodel,
 			}
 		}
 	}
+	if (vk_zfix->value)
+		vkCmdSetDepthBias(vk_activeCmdbuffer, 0.0f, 0.0f, 0.0f);
 }
 
 void


### PR DESCRIPTION
Matches gl_zfix from gl1/gl3/gl4. Uses VK_DYNAMIC_STATE_DEPTH_BIAS so the cvar toggles at runtime without vid_restart; depthBiasEnable is flipped on vk_drawPolyPipeline and vk_drawPolyLmapPipeline, with vkCmdSetDepthBias set/reset around the inline-bmodel loop and zeroed once per frame after QVk_BeginRenderpass(RP_WORLD) so the world draw doesn't sample undefined bias state.