### PR TITLE
sound: drop dead pre-zero of loop sound list

### DIFF
--- a/src/client/sound/openal.c
+++ b/src/client/sound/openal.c
@@ -869,7 +869,6 @@ AL_AddLoopSounds(void)
 		return;
 	}
 
-	memset(&sounds, 0, sizeof(int) * MAX_EDICTS);
 	S_BuildSoundList(sounds);
 
 	for (i = 0; i < cl.frame.num_entities; i++)

--- a/src/client/sound/sdl.c
+++ b/src/client/sound/sdl.c
@@ -692,7 +692,6 @@ SDL_AddLoopSounds(void)
 		return;
 	}
 
-	memset(&sounds, 0, sizeof(int) * MAX_EDICTS);
 	S_BuildSoundList(sounds);
 
 	for (i = 0; i < cl.frame.num_entities; i++)


### PR DESCRIPTION
S_BuildSoundList unconditionally writes sounds[0..cl.frame.num_entities) in every branch, and both AL_AddLoopSounds and SDL_AddLoopSounds only read that same range, so the preceding memset has no readable effect.