### PR TITLE
Fix jerky rotation animation for func_rotating entities in Call of the Machine

### DIFF
--- a/src/client/cl_parse.c
+++ b/src/client/cl_parse.c
@@ -406,17 +406,17 @@ CL_ParseDelta(const entity_xstate_t *from, entity_xstate_t *to, int number, int 
 
 	if (bits & U_ANGLE1)
 	{
-		to->angles[0] = MSG_ReadAngle(&net_message);
+		to->angles[0] = MSG_ReadAngle(&net_message, cls.serverProtocol);
 	}
 
 	if (bits & U_ANGLE2)
 	{
-		to->angles[1] = MSG_ReadAngle(&net_message);
+		to->angles[1] = MSG_ReadAngle(&net_message, cls.serverProtocol);
 	}
 
 	if (bits & U_ANGLE3)
 	{
-		to->angles[2] = MSG_ReadAngle(&net_message);
+		to->angles[2] = MSG_ReadAngle(&net_message, cls.serverProtocol);
 	}
 
 	if (bits & U_OLDORIGIN)

--- a/src/common/header/common.h
+++ b/src/common/header/common.h
@@ -120,7 +120,7 @@ void MSG_WriteFloat(sizebuf_t *sb, float f);
 void MSG_WriteString(sizebuf_t *sb, const char *s);
 void MSG_WriteCoord(sizebuf_t *sb, float f, int protocol);
 void MSG_WritePos(sizebuf_t *sb, const vec3_t pos, int protocol);
-void MSG_WriteAngle(sizebuf_t *sb, float f);
+void MSG_WriteAngle(sizebuf_t *sb, float f, int protocol);
 void MSG_WriteAngle16(sizebuf_t *sb, float f);
 void MSG_WriteConfigString(sizebuf_t *buf, short index, const char *s);
 void MSG_WriteDeltaUsercmd(sizebuf_t *buf, const struct usercmd_s *from,
@@ -142,7 +142,7 @@ char *MSG_ReadStringLine(sizebuf_t *msg_read);
 
 float MSG_ReadCoord(sizebuf_t *msg_read, int protocol);
 void MSG_ReadPos(sizebuf_t *msg_read, vec3_t pos, int protocol);
-float MSG_ReadAngle(sizebuf_t *msg_read);
+float MSG_ReadAngle(sizebuf_t *msg_read, int protocol);
 float MSG_ReadAngle16(sizebuf_t *msg_read);
 void MSG_ReadDeltaUsercmd(sizebuf_t *msg_read,
 		const struct usercmd_s *from,

--- a/src/common/movemsg.c
+++ b/src/common/movemsg.c
@@ -575,7 +575,7 @@ MSG_DeltaEntity_Size(const entity_xstate_t *from, const entity_xstate_t *to,
 
 	if (bits & U_ANGLE2)
 	{
-		sz++;
+		sz+=2;
 	}
 
 	if (bits & U_ANGLE3)
@@ -699,7 +699,7 @@ MSG_WritePos(sizebuf_t *sb, const vec3_t pos, int protocol)
 void
 MSG_WriteAngle(sizebuf_t *sb, float f)
 {
-	MSG_WriteByte(sb, (int)(f * 256 / 360) & 255);
+	MSG_WriteShort(sb, (int)(f * 65536.0 / 360.0) & 0xFFFF);
 }
 
 void
@@ -1333,7 +1333,7 @@ MSG_ReadPos(sizebuf_t *msg_read, vec3_t pos, int protocol)
 float
 MSG_ReadAngle(sizebuf_t *msg_read)
 {
-	return MSG_ReadChar(msg_read) * 1.40625f;
+	return MSG_ReadShort(msg_read) * 360.0 / 65536.0;
 }
 
 float

--- a/src/common/movemsg.c
+++ b/src/common/movemsg.c
@@ -570,17 +570,17 @@ MSG_DeltaEntity_Size(const entity_xstate_t *from, const entity_xstate_t *to,
 
 	if (bits & U_ANGLE1)
 	{
-		sz++;
+		sz += IS_QII97_PROTOCOL(protocol) ? 1 : 2;
 	}
 
 	if (bits & U_ANGLE2)
 	{
-		sz+=2;
+		sz += IS_QII97_PROTOCOL(protocol) ? 1 : 2;
 	}
 
 	if (bits & U_ANGLE3)
 	{
-		sz++;
+		sz += IS_QII97_PROTOCOL(protocol) ? 1 : 2;
 	}
 
 	if (bits & U_OLDORIGIN)
@@ -697,9 +697,16 @@ MSG_WritePos(sizebuf_t *sb, const vec3_t pos, int protocol)
 }
 
 void
-MSG_WriteAngle(sizebuf_t *sb, float f)
+MSG_WriteAngle(sizebuf_t *sb, float f, int protocol)
 {
-	MSG_WriteShort(sb, (int)(f * 65536.0 / 360.0) & 0xFFFF);
+	if (IS_QII97_PROTOCOL(protocol))
+	{
+		MSG_WriteAngle16(sb, f);
+	}
+	else
+	{
+		MSG_WriteByte(sb, (int)(f * 256 / 360) & 255);
+	}
 }
 
 void
@@ -1097,17 +1104,17 @@ MSG_WriteDeltaEntity(const entity_xstate_t *from,
 
 	if (bits & U_ANGLE1)
 	{
-		MSG_WriteAngle(msg, to->angles[0]);
+		MSG_WriteAngle(msg, to->angles[0], protocol);
 	}
 
 	if (bits & U_ANGLE2)
 	{
-		MSG_WriteAngle(msg, to->angles[1]);
+		MSG_WriteAngle(msg, to->angles[1], protocol);
 	}
 
 	if (bits & U_ANGLE3)
 	{
-		MSG_WriteAngle(msg, to->angles[2]);
+		MSG_WriteAngle(msg, to->angles[2], protocol);
 	}
 
 	if (bits & U_OLDORIGIN)
@@ -1331,9 +1338,16 @@ MSG_ReadPos(sizebuf_t *msg_read, vec3_t pos, int protocol)
 }
 
 float
-MSG_ReadAngle(sizebuf_t *msg_read)
+MSG_ReadAngle(sizebuf_t *msg_read, int protocol)
 {
-	return MSG_ReadShort(msg_read) * 360.0 / 65536.0;
+	if (IS_QII97_PROTOCOL(protocol))
+	{
+		return MSG_ReadAngle16(msg_read);
+	}
+	else
+	{
+		return MSG_ReadChar(msg_read) * 1.40625f;
+	}
 }
 
 float

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -384,7 +384,7 @@ PF_WriteDir(const vec3_t dir)
 static void
 PF_WriteAngle(float f)
 {
-	MSG_WriteAngle(&sv.multicast, f);
+	MSG_WriteAngle(&sv.multicast, f, SV_GetRecomendedProtocol());
 }
 
 /*


### PR DESCRIPTION
**Problem**

https://github.com/yquake2/yquake2remaster/issues/62#issue-3779478730

On the `mguhub` map in the Call of the Machine expansion, the rotating ring moves jerkily, while in the official Nightdive remaster the animation is smooth. Interpolation work great, but we have problem with server/client communication

**Root Cause**

-  Angles for func_rotating are sent from server to client in 1 byte (MSG_WriteByte / MSG_ReadChar), providing only 1.4 degrees of precision per step.

- Due to low precision, multiple consecutive angle values on the server collapse into the same byte, causing the client not to see smooth changes.

**My solution**

- Changed the angle transfer format from 1 byte to 2 bytes (MSG_WriteShort / MSG_ReadShort).

- Precision increased from 1.4° to 0.0055°.

- Rotating objects now have _smooth_ animation.

**Alternatives**

If backward compatibility is critical, I can rework this PR with an optional protocol flag for 2-byte angles.

I look forward to your feedback and am ready to make any necessary changes.