### PR TITLE
fix out-of-bounds accesses in pk3 load, key binding and save menu

### DIFF
--- a/src/client/cl_keyboard.c
+++ b/src/client/cl_keyboard.c
@@ -831,7 +831,7 @@ Key_StringToKeynum(const char *str)
 
 	if (!str[1])
 	{
-		return str[0];
+		return (unsigned char)str[0];
 	}
 
 	for (kn = keynames; kn->name; kn++)

--- a/src/client/menu/menu.c
+++ b/src/client/menu/menu.c
@@ -3986,6 +3986,7 @@ Create_Savestrings(void)
 		{
 			FS_Read(m_savestrings[i], sizeof(m_savestrings[i]), f);
 			FS_FCloseFile(f);
+			m_savestrings[i][sizeof(m_savestrings[i]) - 1] = 0;
 			m_savevalid[i] = true;
 		}
 	}

--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -1858,7 +1858,7 @@ FS_LoadPK3(const char *packPath)
 	/* Parse the directory. */
 	status = unzGoToFirstFile(handle);
 
-	while (status == UNZ_OK)
+	while (status == UNZ_OK && i < numFiles)
 	{
 		char fileName[MAX_FILENAME] = {0}; /* File name. */
 


### PR DESCRIPTION
- filesystem: bound pk3 directory parse loop to allocated file count
- client: cast single-byte key token to unsigned in Key_StringToKeynum
- menu: null-terminate save comment read from server.ssv