### PR TITLE
monster: refresh frame bounds after endfunc changes the move

### DIFF
--- a/src/game/g_monster.c
+++ b/src/game/g_monster.c
@@ -1184,6 +1184,22 @@ M_MoveFrame(edict_t *self)
 				/* regrab move, endfunc is very likely to change it */
 				move = self->monsterinfo.currentmove;
 
+				/* we need to recompute as endfunc may have swapped to a move with a different frame range */
+				if (move)
+				{
+					firstframe = move->firstframe;
+					lastframe = move->lastframe;
+
+					reverse = false;
+
+					if (lastframe < firstframe)
+					{
+						reverse = true;
+						firstframe = move->lastframe;
+						lastframe = move->firstframe;
+					}
+				}
+
 				/* check for death */
 				if (self->svflags & SVF_DEADMONSTER)
 				{


### PR DESCRIPTION
Regression introduced by the remaster's M_MoveFrame refactor. Stock yquake2 reads move->firstframe/lastframe directly at every use, so the bounds always track the current move. The remaster caches them in locals once at function entry, but move->endfunc can swap currentmove to a move with a different frame range. The clamp and index then keep using the old bounds while indexing the new move's frame[] array, so a monster holding its last frame (AI_HOLD_FRAME) whose endfunc switches to a shorter move reads move->frame[] out of bounds and calls a garbage aifunc/thinkfunc pointer. Recompute the bounds from the re-grabbed move, restoring the stock invariant.