### PR TITLE
server: skip unicast to non-connected client slots

### DIFF
--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -56,6 +56,12 @@ PF_Unicast(const edict_t *ent, qboolean reliable)
 
 	client = svs.clients + (p - 1);
 
+	if (client->state <= cs_zombie)
+	{
+		SZ_Clear(&sv.multicast);
+		return;
+	}
+
 	if (reliable)
 	{
 		SZ_Write(&client->netchan.message, sv.multicast.data,


### PR DESCRIPTION
Bots are game-side edicts only and never get a real netchan, so their svs.clients slot stays cs_free with an uninitialised message buffer (maxsize 0, allowoverflow false). Unicasting the deathmatch scoreboard to a dead bot hit SZ_GetSpace with allowoverflow unset and aborted the server. Skip free/zombie slots in PF_Unicast and clear the staged multicast.

Refs https://github.com/yquake2/yquake2remaster/pull/150#issuecomment-4758912037