### PR TITLE
sound: drop per-frame redundant work in ogg read and openal update

### DIFF
--- a/src/client/sound/ogg.c
+++ b/src/client/sound/ogg.c
@@ -283,7 +283,7 @@ OGG_InitTrackList(void)
 void
 static OGG_Read(void)
 {
-	short samples[4096] = {0};
+	short samples[4096];
 	float volume = (ogg_mutemusic == true) ? 0.0f : ogg_volume->value;
 
 	int read_samples = stb_vorbis_get_samples_short_interleaved(ogg_file, ogg_file->channels, samples,

--- a/src/client/sound/openal.c
+++ b/src/client/sound/openal.c
@@ -1114,7 +1114,6 @@ AL_Update(void)
 	/* set listener (player) parameters */
 	AL_CopyVector(listener_forward, orientation);
 	AL_CopyVector(listener_up, orientation + 3);
-	qalDistanceModel(AL_LINEAR_DISTANCE_CLAMPED);
 	qalListener3f(AL_POSITION, AL_UnpackVector(listener_origin));
 	qalListenerfv(AL_ORIENTATION, orientation);
 
@@ -1436,6 +1435,8 @@ AL_Init(void)
 	if (s_doppler->value) {
 		qalDopplerFactor(2.0f);
 	}
+
+	qalDistanceModel(AL_LINEAR_DISTANCE_CLAMPED);
 
 	return true;
 }


### PR DESCRIPTION
OGG_Read no longer zero-fills its 8 KB sample buffer each call; the decoder fills it and only the returned sample count is consumed. The OpenAL distance model is a runtime constant, so set it once in AL_Init instead of every frame in AL_Update.