### PR TITLE
sound: re-attach openal occlusion filter every frame

### DIFF
--- a/src/client/sound/openal.c
+++ b/src/client/sound/openal.c
@@ -670,11 +670,8 @@ AL_Spatialize(channel_t *ch)
 					AL_LOWPASS_MAX_GAINHF);
 				qalFilterf(occlusionFilter, AL_LOWPASS_GAINHF, gain_hf);
 
-				if (ch->last_direct_filter != (int)occlusionFilter)
-				{
-					qalSourcei(ch->srcnum, AL_DIRECT_FILTER, occlusionFilter);
-					ch->last_direct_filter = occlusionFilter;
-				}
+				qalSourcei(ch->srcnum, AL_DIRECT_FILTER, occlusionFilter);
+				ch->last_direct_filter = occlusionFilter;
 
 				source_occluded = true;
 			}


### PR DESCRIPTION
The occlusion low-pass filter's GAINHF is recomputed per source each frame, but caching by filter handle skipped the re-attach after the first occluded frame. OpenAL copies filter parameters into the source at attach time, so the distance-dependent HF attenuation froze at its first value. Always re-attach in the occlusion path; the handle cache stays valid only for the static no-filter and underwater cases.