### PR TITLE
shared: use int64_t for 64-bit endian helpers and SiN Reloaded structs

### DIFF
--- a/src/common/header/files.h
+++ b/src/common/header/files.h
@@ -75,8 +75,8 @@ typedef struct
 typedef struct {
 	int ident;
 	int version;
-	long dirofs;
-	long strofs;
+	int64_t dirofs;
+	int64_t strofs;
 	int dirlen;
 	int strlen;
 } dsinrheader_t;
@@ -89,7 +89,7 @@ typedef struct
 
 typedef struct
 {
-	long filepos, filelen;
+	int64_t filepos, filelen;
 } dsinrfile_t;
 
 /* The .pak files are just a linear collapse of a directory tree */

--- a/src/common/header/shared.h
+++ b/src/common/header/shared.h
@@ -409,8 +409,8 @@ int BigLong(int l);
 int LittleLong(int l);
 float BigFloat(float l);
 float LittleFloat(float l);
-long BigLongLong(long l);
-long LittleLongLong(long l);
+int64_t BigLongLong(int64_t l);
+int64_t LittleLongLong(int64_t l);
 
 void Swap_Init(void);
 char *va(const char *format, ...)  PRINTF_ATTR(1, 2);

--- a/src/common/header/shared.h
+++ b/src/common/header/shared.h
@@ -36,6 +36,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <time.h>
 #include <stdbool.h>
 

--- a/src/common/shared/shared.c
+++ b/src/common/shared/shared.c
@@ -866,8 +866,8 @@ static int (*_BigLong)(int l);
 static int (*_LittleLong)(int l);
 static float (*_BigFloat)(float l);
 static float (*_LittleFloat)(float l);
-static long (*_BigLongLong)(long l);
-static long (*_LittleLongLong)(long l);
+static int64_t (*_BigLongLong)(int64_t l);
+static int64_t (*_LittleLongLong)(int64_t l);
 
 short
 BigShort(short l)
@@ -905,14 +905,14 @@ LittleFloat(float l)
 	return _LittleFloat(l);
 }
 
-long
-BigLongLong(long l)
+int64_t
+BigLongLong(int64_t l)
 {
 	return _BigLongLong(l);
 }
 
-long
-LittleLongLong(long l)
+int64_t
+LittleLongLong(int64_t l)
 {
 	return _LittleLongLong(l);
 }
@@ -953,8 +953,8 @@ LongNoSwap(int l)
 	return l;
 }
 
-static long
-LongLongSwap(long l)
+static int64_t
+LongLongSwap(int64_t l)
 {
 	byte b1, b2, b3, b4, b5, b6, b7, b8;
 
@@ -968,14 +968,14 @@ LongLongSwap(long l)
 	b8 = (l >> 56) & 255;
 
 	return (
-		((long)b1 << 56) + ((long)b2 << 48) +
-		((long)b3 << 40) + ((long)b4 << 32) +
-		((long)b5 << 24) + ((long)b6 << 16) +
-		((long)b7 << 8) + b8);
+		((int64_t)b1 << 56) + ((int64_t)b2 << 48) +
+		((int64_t)b3 << 40) + ((int64_t)b4 << 32) +
+		((int64_t)b5 << 24) + ((int64_t)b6 << 16) +
+		((int64_t)b7 << 8) + b8);
 }
 
-static long
-LongLongNoSwap(long l)
+static int64_t
+LongLongNoSwap(int64_t l)
 {
 	return l;
 }


### PR DESCRIPTION
long is 32-bit on Windows (LLP64), breaking the 64-bit offset fields.