### PR TITLE
models: use bone rotation matrices in skeletal skinning

### DIFF
--- a/src/client/refresh/files/mesh.c
+++ b/src/client/refresh/files/mesh.c
@@ -183,6 +183,14 @@ R_SkeletalVerts(const dmdx_t *pheader, int frame, int oldframe, float frontlerp,
 
 	YQ2_VLA(skeletal_bone_t, bonematrix, pheader->num_joints);
 
+#ifdef _MSC_VER
+	/* _malloca() can fail, a VLA can not */
+	if (!bonematrix)
+	{
+		return;
+	}
+#endif
+
 	poses = (const dmdx_baseframe_joint_t *)((const byte *)pheader + pheader->ofs_baseframe_joints)
 	        + frame * pheader->num_joints;
 	old_poses = (const dmdx_baseframe_joint_t *)((const byte *)pheader + pheader->ofs_baseframe_joints)

--- a/src/client/refresh/files/mesh.c
+++ b/src/client/refresh/files/mesh.c
@@ -121,6 +121,12 @@ R_StaticVerts(qboolean powerUpEffect, int nverts,
 	}
 }
 
+typedef struct
+{
+	float rot[9];
+	vec3_t pos;
+} skeletal_bone_t;
+
 /* quaternion slerp for bone interpolation; assumes unit quaternions */
 static void
 BoneSlerp(const vec4_t qa, const vec4_t qb, float t, vec4_t out)
@@ -175,7 +181,7 @@ R_SkeletalVerts(const dmdx_t *pheader, int frame, int oldframe, float frontlerp,
 	const dmdx_vertex_t *mesh_verteces;
 	int num_joints, num_verts, num_weights, i;
 
-	YQ2_VLA(dmdx_joint_t, bonematrix, pheader->num_joints);
+	YQ2_VLA(skeletal_bone_t, bonematrix, pheader->num_joints);
 
 	poses = (const dmdx_baseframe_joint_t *)((const byte *)pheader + pheader->ofs_baseframe_joints)
 	        + frame * pheader->num_joints;
@@ -191,17 +197,17 @@ R_SkeletalVerts(const dmdx_t *pheader, int frame, int oldframe, float frontlerp,
 	for (i = 0; i < num_joints; i++)
 	{
 		vec4_t lorient;
-		vec3_t lpos;
 		int n;
 
 		for (n = 0; n < 3; n++)
 		{
-			lpos[n] = old_poses[i].pos[n] * backlerp + poses[i].pos[n] * frontlerp;
+			bonematrix[i].pos[n] = old_poses[i].pos[n] * backlerp +
+				poses[i].pos[n] * frontlerp;
 		}
 
 		BoneSlerp(old_poses[i].orient, poses[i].orient, frontlerp, lorient);
-		memcpy(bonematrix[i].pos, lpos, sizeof(vec3_t));
-		memcpy(bonematrix[i].orient, lorient, sizeof(quat_t));
+		Quat_normalize(lorient);
+		Quat_toMat3(lorient, bonematrix[i].rot);
 	}
 
 	/* skin each vertex */
@@ -219,8 +225,8 @@ R_SkeletalVerts(const dmdx_t *pheader, int frame, int oldframe, float frontlerp,
 		for (k = 0; k < count; k++)
 		{
 			const dmdx_weight_t *weight;
-			const dmdx_joint_t *joint;
-			vec3_t wv;
+			const skeletal_bone_t *joint;
+			const float *m, *p;
 
 			weight = &weights[bind->start + k];
 
@@ -230,12 +236,13 @@ R_SkeletalVerts(const dmdx_t *pheader, int frame, int oldframe, float frontlerp,
 			}
 
 			joint = bonematrix + weight->joint;
+			m = joint->rot;
+			p = weight->pos;
 
-			Quat_rotatePoint(joint->orient, weight->pos, wv);
 			/* The sum of all weight->bias should be 1.0 */
-			result[0] += (joint->pos[0] + wv[0]) * weight->bias;
-			result[1] += (joint->pos[1] + wv[1]) * weight->bias;
-			result[2] += (joint->pos[2] + wv[2]) * weight->bias;
+			result[0] += (joint->pos[0] + m[0] * p[0] + m[1] * p[1] + m[2] * p[2]) * weight->bias;
+			result[1] += (joint->pos[1] + m[3] * p[0] + m[4] * p[1] + m[5] * p[2]) * weight->bias;
+			result[2] += (joint->pos[2] + m[6] * p[0] + m[7] * p[1] + m[8] * p[2]) * weight->bias;
 		}
 
 		lerp[0] = scale[0] * (result[0] + move[0]);

--- a/src/common/models/mesh.c
+++ b/src/common/models/mesh.c
@@ -31,7 +31,7 @@ void
 Quat_normalize(quat_t q)
 {
 	/* compute magnitude of the quaternion */
-	float mag = sqrt ((q[0] * q[0]) + (q[1] * q[1])
+	float mag = sqrtf ((q[0] * q[0]) + (q[1] * q[1])
 		+ (q[2] * q[2]) + (q[3] * q[3]));
 
 	/* check for bogus length, to protect against divide by zero */
@@ -72,4 +72,26 @@ Quat_rotatePoint(const quat_t q, const vec3_t in, vec3_t out)
 	out[0] = final[0];
 	out[1] = final[1];
 	out[2] = final[2];
+}
+
+/* rotation matrix of a unit quaternion, row major */
+void
+Quat_toMat3(const quat_t q, float m[9])
+{
+	const float x2 = q[0] + q[0], y2 = q[1] + q[1], z2 = q[2] + q[2];
+	const float xx = q[0] * x2, xy = q[0] * y2, xz = q[0] * z2;
+	const float yy = q[1] * y2, yz = q[1] * z2, zz = q[2] * z2;
+	const float wx = q[3] * x2, wy = q[3] * y2, wz = q[3] * z2;
+
+	m[0] = 1.0f - (yy + zz);
+	m[1] = xy - wz;
+	m[2] = xz + wy;
+
+	m[3] = xy + wz;
+	m[4] = 1.0f - (xx + zz);
+	m[5] = yz - wx;
+
+	m[6] = xz - wy;
+	m[7] = yz + wx;
+	m[8] = 1.0f - (xx + yy);
 }

--- a/src/common/models/mesh.h
+++ b/src/common/models/mesh.h
@@ -31,5 +31,6 @@
 
 void Quat_normalize(quat_t q);
 void Quat_rotatePoint(const quat_t q, const vec3_t in, vec3_t out);
+void Quat_toMat3(const quat_t q, float m[9]);
 
 #endif /* SRC_COMMON_MODELS_MESH_H_ */


### PR DESCRIPTION
Converting each joint quaternion to a matrix once lifts the quaternion algebra out of the per-weight loop, ~3x faster in R_SkeletalVerts.