### PR TITLE
Center GL rendering in fullscreen display

### DIFF
--- a/doc/030_configuration.md
+++ b/doc/030_configuration.md
@@ -22,6 +22,8 @@ Yamagi Quake II ships with 4 renderers:
   uses OpenGL ES 3.0 instead of "desktop" OpenGL, so it also works on
   the Raspberry Pi 4, for example. Reportedly it also has slightly
   better performance on Wayland, at least with the open source AMD drivers.
+  It is not available on macOS, where SDL's Cocoa backend does not provide
+  an OpenGL ES context.
 * The **OpenGL 1.4** renderer: This is a slightly enhanced version of
   the original OpenGL renderer shipped in 1997 with the retail release.
   It's provided for older graphics cards, not able to run the OpenGL 3.2

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -47,6 +47,13 @@ image_t *r_particletexture; /* little dot for particles */
 
 int c_brush_polys, c_alias_polys;
 
+static int gl1_drawable_width;
+static int gl1_drawable_height;
+static int gl1_viewport_x;
+static int gl1_viewport_y;
+static int gl1_viewport_width;
+static int gl1_viewport_height;
+
 float v_blend[4]; /* final blending color */
 
 /* view origin */
@@ -629,6 +636,47 @@ R_ResetClearColor(void)
 }
 
 static void
+R_UpdateViewport(void)
+{
+	RI_GetDrawableSize(&gl1_drawable_width, &gl1_drawable_height);
+
+	if (gl1_drawable_width <= 0)
+	{
+		gl1_drawable_width = vid.width;
+	}
+	if (gl1_drawable_height <= 0)
+	{
+		gl1_drawable_height = vid.height;
+	}
+
+	gl1_viewport_x = gl1_drawable_width > vid.width ?
+		(gl1_drawable_width - vid.width) / 2 : 0;
+	gl1_viewport_y = gl1_drawable_height > vid.height ?
+		(gl1_drawable_height - vid.height) / 2 : 0;
+	gl1_viewport_width = gl1_drawable_width < vid.width ?
+		gl1_drawable_width : vid.width;
+	gl1_viewport_height = gl1_drawable_height < vid.height ?
+		gl1_drawable_height : vid.height;
+}
+
+static void
+R_ClearViewportBars(void)
+{
+	if (gl1_viewport_x == 0 && gl1_viewport_y == 0
+		&& gl1_viewport_width == gl1_drawable_width
+		&& gl1_viewport_height == gl1_drawable_height)
+	{
+		return;
+	}
+
+	glDisable(GL_SCISSOR_TEST);
+	glViewport(0, 0, gl1_drawable_width, gl1_drawable_height);
+	glClearColor(0, 0, 0, 1);
+	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+	R_ResetClearColor();
+}
+
+static void
 R_SetupFrame(void)
 {
 	int i;
@@ -657,8 +705,8 @@ R_SetupFrame(void)
 	{
 		glEnable(GL_SCISSOR_TEST);
 		glClearColor(0.3, 0.3, 0.3, 1);
-		glScissor(r_newrefdef.x,
-				vid.height - r_newrefdef.height - r_newrefdef.y,
+		glScissor(gl1_viewport_x + r_newrefdef.x,
+				gl1_viewport_y + vid.height - r_newrefdef.height - r_newrefdef.y,
 				r_newrefdef.width, r_newrefdef.height);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 		R_ResetClearColor();
@@ -729,7 +777,7 @@ R_SetupGL(void)
 		y2 = drawing_left_eye ? (y2 + vid.height) / 2 : (y2 / 2);
 	}
 
-	glViewport(x, y2, w, h);
+	glViewport(gl1_viewport_x + x, gl1_viewport_y + y2, w, h);
 
 	/* set up projection matrix */
 	glMatrixMode(GL_PROJECTION);
@@ -893,9 +941,9 @@ R_SetGL2D(void)
 	qboolean stereo_split_lr = ((gl_state.stereo_mode == STEREO_SPLIT_HORIZONTAL) && gl_state.camera_separation);
 
 	x = 0;
-	w = vid.width;
+	w = gl1_viewport_width;
 	y = 0;
-	h = vid.height;
+	h = gl1_viewport_height;
 
 	if (stereo_split_lr) {
 		w =  w / 2;
@@ -907,7 +955,7 @@ R_SetGL2D(void)
 		y = drawing_left_eye ? h : 0;
 	}
 
-	glViewport(x, y, w, h);
+	glViewport(gl1_viewport_x + x, gl1_viewport_y + y, w, h);
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
 	glOrtho(0, vid.width, vid.height, 0, -99999, 99999);
@@ -1773,6 +1821,9 @@ RI_BeginFrame(float camera_separation)
 	}
 
 	/* go into 2D mode */
+	R_UpdateViewport();
+	R_ClearViewportBars();
+
 	R_SetGL2D();
 
 	if (gl1_particle_square->modified)

--- a/src/client/refresh/gl1/gl1_sdl.c
+++ b/src/client/refresh/gl1/gl1_sdl.c
@@ -372,6 +372,32 @@ int RI_InitContext(void* win)
 void RI_GetDrawableSize(int* width, int* height)
 {
 #ifdef USE_SDL3
+	if (SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN)
+	{
+		SDL_DisplayID display = SDL_GetDisplayForWindow(window);
+		const SDL_DisplayMode *mode = display != 0 ? SDL_GetCurrentDisplayMode(display) : NULL;
+		if (mode != NULL)
+		{
+			*width = mode->w;
+			*height = mode->h;
+			return;
+		}
+	}
+#else
+	if (SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN)
+	{
+		int display = SDL_GetWindowDisplayIndex(window);
+		SDL_DisplayMode mode;
+		if (display >= 0 && SDL_GetCurrentDisplayMode(display, &mode) == 0)
+		{
+			*width = mode.w;
+			*height = mode.h;
+			return;
+		}
+	}
+#endif
+
+#ifdef USE_SDL3
 	SDL_GetWindowSizeInPixels(window, width, height);
 #else
 	SDL_GL_GetDrawableSize(window, width, height);

--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -65,6 +65,13 @@ vec3_t gl3_origin;
 
 int c_brush_polys, c_alias_polys;
 
+static int gl3_drawable_width;
+static int gl3_drawable_height;
+static int gl3_viewport_x;
+static int gl3_viewport_y;
+static int gl3_viewport_width;
+static int gl3_viewport_height;
+
 static float v_blend[4]; /* final blending color */
 
 const hmm_mat4 gl3_identityMat4 = {{
@@ -421,6 +428,47 @@ GL3_ResetClearColor(void)
 	else
 #endif
 		glClearColor(1, 0, 0.5, 0.5);
+}
+
+static void
+GL3_UpdateViewport(void)
+{
+	GL3_GetDrawableSize(&gl3_drawable_width, &gl3_drawable_height);
+
+	if (gl3_drawable_width <= 0)
+	{
+		gl3_drawable_width = vid.width;
+	}
+	if (gl3_drawable_height <= 0)
+	{
+		gl3_drawable_height = vid.height;
+	}
+
+	gl3_viewport_x = gl3_drawable_width > vid.width ?
+		(gl3_drawable_width - vid.width) / 2 : 0;
+	gl3_viewport_y = gl3_drawable_height > vid.height ?
+		(gl3_drawable_height - vid.height) / 2 : 0;
+	gl3_viewport_width = gl3_drawable_width < vid.width ?
+		gl3_drawable_width : vid.width;
+	gl3_viewport_height = gl3_drawable_height < vid.height ?
+		gl3_drawable_height : vid.height;
+}
+
+static void
+GL3_ClearViewportBars(void)
+{
+	if (gl3_viewport_x == 0 && gl3_viewport_y == 0
+		&& gl3_viewport_width == gl3_drawable_width
+		&& gl3_viewport_height == gl3_drawable_height)
+	{
+		return;
+	}
+
+	glDisable(GL_SCISSOR_TEST);
+	glViewport(0, 0, gl3_drawable_width, gl3_drawable_height);
+	glClearColor(0, 0, 0, 1);
+	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+	GL3_ResetClearColor();
 }
 
 static qboolean
@@ -1367,8 +1415,8 @@ SetupFrame(void)
 	{
 		glEnable(GL_SCISSOR_TEST);
 		glClearColor(0.3, 0.3, 0.3, 1);
-		glScissor(r_newrefdef.x,
-				vid.height - r_newrefdef.height - r_newrefdef.y,
+		glScissor(gl3_viewport_x + r_newrefdef.x,
+				gl3_viewport_y + vid.height - r_newrefdef.height - r_newrefdef.y,
 				r_newrefdef.width, r_newrefdef.height);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 		GL3_ResetClearColor();
@@ -1380,9 +1428,9 @@ static void
 GL3_SetGL2D(void)
 {
 	int x = 0;
-	int w = vid.width;
+	int w = gl3_viewport_width;
 	int y = 0;
-	int h = vid.height;
+	int h = gl3_viewport_height;
 
 #if 0 // TODO: stereo
 	/* set 2D virtual screen size */
@@ -1401,7 +1449,7 @@ GL3_SetGL2D(void)
 	}
 #endif // 0
 
-	glViewport(x, y, w, h);
+	glViewport(gl3_viewport_x + x, gl3_viewport_y + y, w, h);
 
 	hmm_mat4 transMatr = HMM_Orthographic(0, vid.width, vid.height, 0, -99999, 99999);
 
@@ -1572,7 +1620,7 @@ SetupGL(void)
 	}
 	else // rendering directly (not to FBO for postprocessing)
 	{
-		glViewport(x, y2, w, h);
+		glViewport(gl3_viewport_x + x, gl3_viewport_y + y2, w, h);
 	}
 
 	/* set up projection matrix (eye coordinates -> clip coordinates) */
@@ -2059,6 +2107,9 @@ GL3_BeginFrame(float camera_separation)
 		GL3_RecreateShaders();
 	}
 
+
+	GL3_UpdateViewport();
+	GL3_ClearViewportBars();
 
 	/* go into 2D mode */
 

--- a/src/client/refresh/gl3/gl3_sdl.c
+++ b/src/client/refresh/gl3/gl3_sdl.c
@@ -482,6 +482,32 @@ int GL3_InitContext(void* win)
 void GL3_GetDrawableSize(int* width, int* height)
 {
 #ifdef USE_SDL3
+	if (SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN)
+	{
+		SDL_DisplayID display = SDL_GetDisplayForWindow(window);
+		const SDL_DisplayMode *mode = display != 0 ? SDL_GetCurrentDisplayMode(display) : NULL;
+		if (mode != NULL)
+		{
+			*width = mode->w;
+			*height = mode->h;
+			return;
+		}
+	}
+#else
+	if (SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN)
+	{
+		int display = SDL_GetWindowDisplayIndex(window);
+		SDL_DisplayMode mode;
+		if (display >= 0 && SDL_GetCurrentDisplayMode(display, &mode) == 0)
+		{
+			*width = mode.w;
+			*height = mode.h;
+			return;
+		}
+	}
+#endif
+
+#ifdef USE_SDL3
 	SDL_GetWindowSizeInPixels(window, width, height);
 #else
 	SDL_GL_GetDrawableSize(window, width, height);

--- a/src/client/refresh/gl4/gl4_main.c
+++ b/src/client/refresh/gl4/gl4_main.c
@@ -61,6 +61,13 @@ vec3_t gl4_origin;
 
 int c_brush_polys, c_alias_polys;
 
+static int gl4_drawable_width;
+static int gl4_drawable_height;
+static int gl4_viewport_x;
+static int gl4_viewport_y;
+static int gl4_viewport_width;
+static int gl4_viewport_height;
+
 static float v_blend[4]; /* final blending color */
 
 const hmm_mat4 gl4_identityMat4 = {{
@@ -92,6 +99,53 @@ cvar_t *gl4_debugcontext;
 cvar_t *gl4_usefbo;
 
 cvar_t *gl4_show_draw_stats;
+
+static void
+GL4_ResetClearColor(void)
+{
+	glClearColor(1, 0, 0.5, 0.5);
+}
+
+static void
+GL4_UpdateViewport(void)
+{
+	GL4_GetDrawableSize(&gl4_drawable_width, &gl4_drawable_height);
+
+	if (gl4_drawable_width <= 0)
+	{
+		gl4_drawable_width = vid.width;
+	}
+	if (gl4_drawable_height <= 0)
+	{
+		gl4_drawable_height = vid.height;
+	}
+
+	gl4_viewport_x = gl4_drawable_width > vid.width ?
+		(gl4_drawable_width - vid.width) / 2 : 0;
+	gl4_viewport_y = gl4_drawable_height > vid.height ?
+		(gl4_drawable_height - vid.height) / 2 : 0;
+	gl4_viewport_width = gl4_drawable_width < vid.width ?
+		gl4_drawable_width : vid.width;
+	gl4_viewport_height = gl4_drawable_height < vid.height ?
+		gl4_drawable_height : vid.height;
+}
+
+static void
+GL4_ClearViewportBars(void)
+{
+	if (gl4_viewport_x == 0 && gl4_viewport_y == 0
+		&& gl4_viewport_width == gl4_drawable_width
+		&& gl4_viewport_height == gl4_drawable_height)
+	{
+		return;
+	}
+
+	glDisable(GL_SCISSOR_TEST);
+	glViewport(0, 0, gl4_drawable_width, gl4_drawable_height);
+	glClearColor(0, 0, 0, 1);
+	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+	GL4_ResetClearColor();
+}
 
 DA_TYPEDEF(mvtx_t, Vtx3DArray_t);
 DA_TYPEDEF(GLushort, UShortArray_t);
@@ -1330,8 +1384,8 @@ SetupFrame(void)
 	{
 		glEnable(GL_SCISSOR_TEST);
 		glClearColor(0.3, 0.3, 0.3, 1);
-		glScissor(r_newrefdef.x,
-				vid.height - r_newrefdef.height - r_newrefdef.y,
+		glScissor(gl4_viewport_x + r_newrefdef.x,
+				gl4_viewport_y + vid.height - r_newrefdef.height - r_newrefdef.y,
 				r_newrefdef.width, r_newrefdef.height);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 		glClearColor(1, 0, 0.5, 0.5);
@@ -1343,9 +1397,9 @@ static void
 GL4_SetGL2D(void)
 {
 	int x = 0;
-	int w = vid.width;
+	int w = gl4_viewport_width;
 	int y = 0;
-	int h = vid.height;
+	int h = gl4_viewport_height;
 
 #if 0 // TODO: stereo
 	/* set 2D virtual screen size */
@@ -1364,7 +1418,7 @@ GL4_SetGL2D(void)
 	}
 #endif // 0
 
-	glViewport(x, y, w, h);
+	glViewport(gl4_viewport_x + x, gl4_viewport_y + y, w, h);
 
 	hmm_mat4 transMatr = HMM_Orthographic(0, vid.width, vid.height, 0, -99999, 99999);
 
@@ -1535,7 +1589,7 @@ SetupGL(void)
 	}
 	else // rendering directly (not to FBO for postprocessing)
 	{
-		glViewport(x, y2, w, h);
+		glViewport(gl4_viewport_x + x, gl4_viewport_y + y2, w, h);
 	}
 
 	/* set up projection matrix (eye coordinates -> clip coordinates) */
@@ -2018,6 +2072,9 @@ GL4_BeginFrame(float camera_separation)
 		GL4_RecreateShaders();
 	}
 
+
+	GL4_UpdateViewport();
+	GL4_ClearViewportBars();
 
 	/* go into 2D mode */
 

--- a/src/client/refresh/gl4/gl4_sdl.c
+++ b/src/client/refresh/gl4/gl4_sdl.c
@@ -442,6 +442,32 @@ int GL4_InitContext(void* win)
 void GL4_GetDrawableSize(int* width, int* height)
 {
 #ifdef USE_SDL3
+	if (SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN)
+	{
+		SDL_DisplayID display = SDL_GetDisplayForWindow(window);
+		const SDL_DisplayMode *mode = display != 0 ? SDL_GetCurrentDisplayMode(display) : NULL;
+		if (mode != NULL)
+		{
+			*width = mode->w;
+			*height = mode->h;
+			return;
+		}
+	}
+#else
+	if (SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN)
+	{
+		int display = SDL_GetWindowDisplayIndex(window);
+		SDL_DisplayMode mode;
+		if (display >= 0 && SDL_GetCurrentDisplayMode(display, &mode) == 0)
+		{
+			*width = mode.w;
+			*height = mode.h;
+			return;
+		}
+	}
+#endif
+
+#ifdef USE_SDL3
 	SDL_GetWindowSizeInPixels(window, width, height);
 #else
 	SDL_GL_GetDrawableSize(window, width, height);

--- a/src/client/vid/glimp_sdl3.c
+++ b/src/client/vid/glimp_sdl3.c
@@ -118,6 +118,86 @@ ClearDisplayIndices(void)
 	SDL_free(displays);
 }
 
+static int GetFullscreenType(void);
+
+static qboolean
+SetWindowFullscreen(int fullscreen, int w, int h)
+{
+	if (GetFullscreenType() != FULLSCREEN_OFF)
+	{
+		if (!SDL_SetWindowFullscreen(window, false))
+		{
+			Com_Printf("Couldn't leave fullscreen: %s\n", SDL_GetError());
+			return false;
+		}
+
+		if (!SDL_SyncWindow(window))
+		{
+			Com_Printf("Couldn't synchronize leaving fullscreen: %s\n", SDL_GetError());
+			return false;
+		}
+	}
+
+	if (fullscreen == FULLSCREEN_OFF)
+	{
+		return true;
+	}
+
+	if (fullscreen == FULLSCREEN_DESKTOP)
+	{
+		if (!SDL_SetWindowFullscreenMode(window, NULL))
+		{
+			Com_Printf("Couldn't set desktop fullscreen mode: %s\n", SDL_GetError());
+			return false;
+		}
+	}
+	else
+	{
+		SDL_DisplayMode closestMode;
+
+		if (vid_rate->value > 0 &&
+				!SDL_GetClosestFullscreenDisplayMode(displays[last_display], w, h,
+						vid_rate->value, true, &closestMode))
+		{
+			Com_Printf("SDL was unable to find a mode close to %ix%i@%f\n", w, h, vid_rate->value);
+			Com_Printf("Retrying with desktop refresh rate\n");
+			Cvar_SetValue("vid_rate", -1);
+		}
+
+		if (vid_rate->value <= 0 &&
+				!SDL_GetClosestFullscreenDisplayMode(displays[last_display], w, h,
+						0, true, &closestMode))
+		{
+			Com_Printf("SDL was unable to find a mode close to %ix%i@0\n", w, h);
+			return false;
+		}
+
+		Com_Printf("User requested %ix%i@%f, setting closest mode %ix%i@%f\n",
+				w, h, vid_rate->value, closestMode.w, closestMode.h,
+				closestMode.refresh_rate);
+
+		if (!SDL_SetWindowFullscreenMode(window, &closestMode))
+		{
+			Com_Printf("Couldn't set closest mode: %s\n", SDL_GetError());
+			return false;
+		}
+	}
+
+	if (!SDL_SetWindowFullscreen(window, true))
+	{
+		Com_Printf("Couldn't enter fullscreen: %s\n", SDL_GetError());
+		return false;
+	}
+
+	if (!SDL_SyncWindow(window))
+	{
+		Com_Printf("Couldn't synchronize entering fullscreen: %s\n", SDL_GetError());
+		return false;
+	}
+
+	return true;
+}
+
 static qboolean
 CreateSDLWindow(SDL_WindowFlags flags, int fullscreen, int w, int h)
 {
@@ -141,7 +221,8 @@ CreateSDLWindow(SDL_WindowFlags flags, int fullscreen, int w, int h)
 	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_Y_NUMBER, last_position_y);
 	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, w);
 	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, h);
-	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_FLAGS_NUMBER, flags);
+	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_FLAGS_NUMBER,
+			flags & ~SDL_WINDOW_FULLSCREEN);
 
 	window = SDL_CreateWindowWithProperties(props);
 	SDL_DestroyProperties(props);
@@ -167,82 +248,20 @@ CreateSDLWindow(SDL_WindowFlags flags, int fullscreen, int w, int h)
 			last_display = GetDisplayIndex(current);
 		}
 
-		/* Set requested fullscreen mode. */
-		if (flags & SDL_WINDOW_FULLSCREEN)
+		/* Set requested fullscreen mode after creating the OpenGL window.
+		 * Cocoa can reject an OpenGL window when the fullscreen flag is
+		 * passed to SDL_CreateWindowWithProperties(). */
+		if (!SetWindowFullscreen(fullscreen, w, h))
 		{
-            /* SDLs behavior changed between SDL 2 and SDL 3: In SDL 2
-			   the fullscreen window could be set with whatever mode
-			   was requested. In SDL 3 the fullscreen window is always
-			   created at desktop resolution. If a fullscreen window
-			   is requested, we can't do anything else and are done here. */
-			if (fullscreen == FULLSCREEN_DESKTOP)
-			{
-				return true;
-			}
-
-			/* Otherwise try to find a mode near the requested one and
-			   switch to it in exclusive fullscreen mode. */
-			SDL_DisplayMode closestMode;
-
-			if (vid_rate->value > 0)
-			{
-				if (SDL_GetClosestFullscreenDisplayMode(displays[last_display], w, h, vid_rate->value, true, &closestMode) != true)
-				{
-					Com_Printf("SDL was unable to find a mode close to %ix%i@%f\n", w, h, vid_rate->value);
-					Com_Printf("Retrying with desktop refresh rate\n");
-
-					/* This is likely pointless. SDL3 walks the complete mode list
-					   when trying to find a matching mode. If it didn't find a
-					   refresh rate above something is very wrong it won't find
-					   one here either. */
-					if (SDL_GetClosestFullscreenDisplayMode(displays[last_display], w, h, 0, true, &closestMode) == true)
-					{
-						Cvar_SetValue("vid_rate", -1);
-					}
-					else
-					{
-						Com_Printf("SDL was unable to find a mode close to %ix%i@0\n", w, h);
-						return false;
-					}
-				}
-			}
-			else
-			{
-				if (SDL_GetClosestFullscreenDisplayMode(displays[last_display], w, h, 0, true, &closestMode) != true)
-				{
-					Com_Printf("SDL was unable to find a mode close to %ix%i@0\n", w, h);
-					return false;
-				}
-			}
-
-			Com_Printf("User requested %ix%i@%f, setting closest mode %ix%i@%f\n",
-					w, h, vid_rate->value, closestMode.w, closestMode.h , closestMode.refresh_rate);
-
-
-			/* TODO SDL3: Same code is in InitGraphics(), refactor into
-			 * a function? */
-			if (!SDL_SetWindowFullscreenMode(window, &closestMode))
-			{
-				Com_Printf("Couldn't set closest mode: %s\n", SDL_GetError());
-				return false;
-			}
-
-			if (!SDL_SetWindowFullscreen(window, true))
-			{
-				Com_Printf("Couldn't switch to exclusive fullscreen: %s\n", SDL_GetError());
-				return false;
-			}
-
-			if (!SDL_SyncWindow(window))
-			{
-				Com_Printf("Couldn't synchronize window state: %s\n", SDL_GetError());
-				return false;
-			}
+			SDL_DestroyWindow(window);
+			window = NULL;
+			return false;
 		}
 	}
 	else
 	{
-		Com_Printf("Creating window failed: %s\n", SDL_GetError());
+		Com_Printf("Creating window failed for %ix%i, fullscreen %i, flags 0x%llx: %s\n",
+				w, h, fullscreen, (unsigned long long)flags, SDL_GetError());
 		return false;
 	}
 
@@ -556,67 +575,21 @@ GLimp_InitGraphics(int fullscreen, int *pwidth, int *pheight)
 	if (initSuccessful && GetWindowSize(&curWidth, &curHeight)
 			&& (curWidth == width) && (curHeight == height))
 	{
-		SDL_DisplayMode closestMode;
+		int currentFullscreen = GetFullscreenType();
 
-
-		/* If we want fullscreen, but aren't */
-		if (GetFullscreenType())
+		if (currentFullscreen != fullscreen)
 		{
-			if (fullscreen == FULLSCREEN_EXCLUSIVE)
+			if (!SetWindowFullscreen(fullscreen, width, height))
 			{
-				if (SDL_GetClosestFullscreenDisplayMode(displays[last_display], width, height, vid_rate->value, false, &closestMode) != true)
-				{
-					Com_Printf("SDL was unable to find a mode close to %ix%i@%f\n", width, height, vid_rate->value);
-
-					if (vid_rate->value != 0)
-					{
-						Com_Printf("Retrying with desktop refresh rate\n");
-
-						if (SDL_GetClosestFullscreenDisplayMode(displays[last_display], width, height, 0, false, &closestMode) == true)
-						{
-							Cvar_SetValue("vid_rate", 0);
-						}
-						else
-						{
-							Com_Printf("SDL was unable to find a mode close to %ix%i@0\n", width, height);
-							return false;
-						}
-					}
-				}
-			}
-			else if (fullscreen == FULLSCREEN_DESKTOP)
-			{
-				/* Fullscreen window */
-				/* closestMode = NULL; */
-			}
-
-			if (!SDL_SetWindowFullscreenMode(window, &closestMode))
-			{
-				Com_Printf("Couldn't set fullscreen modmode: %s\n", SDL_GetError());
+				Com_Printf("SDL fullscreen transition failed: %s\n", SDL_GetError());
 				Cvar_SetValue("vid_fullscreen", 0);
-			}
-			else
-			{
-				if (!SDL_SetWindowFullscreen(window, true))
-				{
-					Com_Printf("Couldn't switch to exclusive fullscreen: %s\n", SDL_GetError());
-					Cvar_SetValue("vid_fullscreen", 0);
-				}
-				else
-				{
-					if (!SDL_SyncWindow(window))
-					{
-						Com_Printf("Couldn't synchronize window state: %s\n", SDL_GetError());
-						Cvar_SetValue("vid_fullscreen", 0);
-					}
-				}
+				return false;
 			}
 
 			Cvar_SetValue("vid_fullscreen", fullscreen);
 		}
 
-		/* Are we now? */
-		if (GetFullscreenType())
+		if (GetFullscreenType() == fullscreen)
 		{
 			return true;
 		}
@@ -675,7 +648,7 @@ GLimp_InitGraphics(int fullscreen, int *pwidth, int *pheight)
 
 				Com_Printf("SDL SetVideoMode failed: %s\n", SDL_GetError());
 				Com_Printf("Reverting to %s r_mode %i (%ix%i) with %dx MSAA.\n",
-					        (flags & fs_flag) ? "fullscreen" : "windowed",
+				        fullscreen != FULLSCREEN_OFF ? "fullscreen" : "windowed",
 					        (int) Cvar_VariableValue("r_mode"), width, height,
 					        msaa_samples);
 

--- a/src/client/vid/vid.c
+++ b/src/client/vid/vid.c
@@ -333,6 +333,17 @@ VID_GetRendererLibPath(const char *renderer, char *path, size_t len)
 qboolean
 VID_HasRenderer(const char *renderer)
 {
+	/* SDL's Cocoa video backend has no OpenGL ES context support. Do not
+	 * advertise renderers that can never initialize on macOS, otherwise the
+	 * renderer fallback enters GLimp_InitGraphics() and resets the user's
+	 * video settings before it can try desktop OpenGL. */
+#ifdef __APPLE__
+	if (Q_stricmp(renderer, "gles1") == 0 || Q_stricmp(renderer, "gles3") == 0)
+	{
+		return false;
+	}
+#endif
+
 	char reflib_path[MAX_OSPATH] = {0};
 	VID_GetRendererLibPath(renderer, reflib_path, sizeof(reflib_path));
 


### PR DESCRIPTION
## What changed

GL1, GL3, and GL4 now center fixed-resolution renders in the active fullscreen display and keep the 2D and scissor paths aligned. Letterbox bars are cleared when needed.

## Why

SDL can report the requested fullscreen window size while the active display mode has different dimensions or aspect ratio, leaving the render viewport anchored at the wrong position.

This is the third stacked change and depends on the fullscreen transition and macOS GLES fallback changes.

## Testing

The SDL3 and forced SDL2 builds passed. Native fullscreen was run with a 2560x1080 render on an active 2560x1440 display mode and exited successfully.

Testing was limited to one macOS setup and one fullscreen configuration. No screenshot-based pixel verification, Windows, Linux, or CI testing was performed.

AI-generated with OpenAI Codex (gpt-5.6-luna xhigh).
