### PR TITLE
Fix macOS SDL3 fullscreen transitions, display selection, and viewport placement

### DIFF
--- a/doc/030_configuration.md
+++ b/doc/030_configuration.md
@@ -22,6 +22,8 @@ Yamagi Quake II ships with 4 renderers:
   uses OpenGL ES 3.0 instead of "desktop" OpenGL, so it also works on
   the Raspberry Pi 4, for example. Reportedly it also has slightly
   better performance on Wayland, at least with the open source AMD drivers.
+  It is not available on macOS, where SDL's Cocoa backend does not provide
+  an OpenGL ES context.
 * The **OpenGL 1.4** renderer: This is a slightly enhanced version of
   the original OpenGL renderer shipped in 1997 with the retail release.
   It's provided for older graphics cards, not able to run the OpenGL 3.2

--- a/src/client/refresh/gl1/gl1_main.c
+++ b/src/client/refresh/gl1/gl1_main.c
@@ -47,6 +47,13 @@ image_t *r_particletexture; /* little dot for particles */
 
 int c_brush_polys, c_alias_polys;
 
+static int gl1_drawable_width;
+static int gl1_drawable_height;
+static int gl1_viewport_x;
+static int gl1_viewport_y;
+static int gl1_viewport_width;
+static int gl1_viewport_height;
+
 float v_blend[4]; /* final blending color */
 
 /* view origin */
@@ -631,6 +638,50 @@ R_ResetClearColor(void)
 }
 
 static void
+R_UpdateViewport(void)
+{
+	gl1_drawable_width = vid.width;
+	gl1_drawable_height = vid.height;
+	RI_GetDrawableSize(&gl1_drawable_width, &gl1_drawable_height);
+
+	if (gl1_drawable_width <= 0)
+	{
+		gl1_drawable_width = vid.width;
+	}
+
+	if (gl1_drawable_height <= 0)
+	{
+		gl1_drawable_height = vid.height;
+	}
+
+	gl1_viewport_x = gl1_drawable_width > vid.width ?
+		(gl1_drawable_width - vid.width) / 2 : 0;
+	gl1_viewport_y = gl1_drawable_height > vid.height ?
+		(gl1_drawable_height - vid.height) / 2 : 0;
+	gl1_viewport_width = gl1_drawable_width < vid.width ?
+		gl1_drawable_width : vid.width;
+	gl1_viewport_height = gl1_drawable_height < vid.height ?
+		gl1_drawable_height : vid.height;
+}
+
+static void
+R_ClearViewportBars(void)
+{
+	if (gl1_viewport_x == 0 && gl1_viewport_y == 0 &&
+		gl1_viewport_width == gl1_drawable_width &&
+		gl1_viewport_height == gl1_drawable_height)
+	{
+		return;
+	}
+
+	glDisable(GL_SCISSOR_TEST);
+	glViewport(0, 0, gl1_drawable_width, gl1_drawable_height);
+	glClearColor(0, 0, 0, 1);
+	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+	R_ResetClearColor();
+}
+
+static void
 R_SetupFrame(void)
 {
 	int i;
@@ -659,8 +710,8 @@ R_SetupFrame(void)
 	{
 		glEnable(GL_SCISSOR_TEST);
 		glClearColor(0.3, 0.3, 0.3, 1);
-		glScissor(r_newrefdef.x,
-				vid.height - r_newrefdef.height - r_newrefdef.y,
+		glScissor(gl1_viewport_x + r_newrefdef.x,
+				gl1_viewport_y + vid.height - r_newrefdef.height - r_newrefdef.y,
 				r_newrefdef.width, r_newrefdef.height);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 		R_ResetClearColor();
@@ -731,7 +782,7 @@ R_SetupGL(void)
 		y2 = drawing_left_eye ? (y2 + vid.height) / 2 : (y2 / 2);
 	}
 
-	glViewport(x, y2, w, h);
+	glViewport(gl1_viewport_x + x, gl1_viewport_y + y2, w, h);
 
 	/* set up projection matrix */
 	glMatrixMode(GL_PROJECTION);
@@ -890,9 +941,9 @@ R_SetGL2D(void)
 	qboolean stereo_split_lr = ((gl_state.stereo_mode == STEREO_SPLIT_HORIZONTAL) && gl_state.camera_separation);
 
 	x = 0;
-	w = vid.width;
+	w = gl1_viewport_width;
 	y = 0;
-	h = vid.height;
+	h = gl1_viewport_height;
 
 	if (stereo_split_lr) {
 		w =  w / 2;
@@ -904,7 +955,7 @@ R_SetGL2D(void)
 		y = drawing_left_eye ? h : 0;
 	}
 
-	glViewport(x, y, w, h);
+	glViewport(gl1_viewport_x + x, gl1_viewport_y + y, w, h);
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
 	glOrtho(0, vid.width, vid.height, 0, -99999, 99999);
@@ -1780,6 +1831,9 @@ RI_BeginFrame(float camera_separation)
 		ri.Cvar_SetValue("gl1_overbrightbits", obb_val);
 		gl1_overbrightbits->modified = false;
 	}
+
+	R_UpdateViewport();
+	R_ClearViewportBars();
 
 	/* go into 2D mode */
 	R_SetGL2D();

--- a/src/client/refresh/gl3/gl3_main.c
+++ b/src/client/refresh/gl3/gl3_main.c
@@ -65,6 +65,13 @@ vec3_t gl3_origin;
 
 int c_brush_polys, c_alias_polys;
 
+static int gl3_drawable_width;
+static int gl3_drawable_height;
+static int gl3_viewport_x;
+static int gl3_viewport_y;
+static int gl3_viewport_width;
+static int gl3_viewport_height;
+
 static float v_blend[4]; /* final blending color */
 
 const hmm_mat4 gl3_identityMat4 = {{
@@ -406,6 +413,50 @@ GL3_ResetClearColor(void)
 	else
 #endif
 		glClearColor(1, 0, 0.5, 0.5);
+}
+
+static void
+GL3_UpdateViewport(void)
+{
+	gl3_drawable_width = vid.width;
+	gl3_drawable_height = vid.height;
+	GL3_GetDrawableSize(&gl3_drawable_width, &gl3_drawable_height);
+
+	if (gl3_drawable_width <= 0)
+	{
+		gl3_drawable_width = vid.width;
+	}
+
+	if (gl3_drawable_height <= 0)
+	{
+		gl3_drawable_height = vid.height;
+	}
+
+	gl3_viewport_x = gl3_drawable_width > vid.width ?
+		(gl3_drawable_width - vid.width) / 2 : 0;
+	gl3_viewport_y = gl3_drawable_height > vid.height ?
+		(gl3_drawable_height - vid.height) / 2 : 0;
+	gl3_viewport_width = gl3_drawable_width < vid.width ?
+		gl3_drawable_width : vid.width;
+	gl3_viewport_height = gl3_drawable_height < vid.height ?
+		gl3_drawable_height : vid.height;
+}
+
+static void
+GL3_ClearViewportBars(void)
+{
+	if (gl3_viewport_x == 0 && gl3_viewport_y == 0 &&
+		gl3_viewport_width == gl3_drawable_width &&
+		gl3_viewport_height == gl3_drawable_height)
+	{
+		return;
+	}
+
+	glDisable(GL_SCISSOR_TEST);
+	glViewport(0, 0, gl3_drawable_width, gl3_drawable_height);
+	glClearColor(0, 0, 0, 1);
+	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+	GL3_ResetClearColor();
 }
 
 static qboolean
@@ -1352,8 +1403,8 @@ SetupFrame(void)
 	{
 		glEnable(GL_SCISSOR_TEST);
 		glClearColor(0.3, 0.3, 0.3, 1);
-		glScissor(r_newrefdef.x,
-				vid.height - r_newrefdef.height - r_newrefdef.y,
+		glScissor(gl3_viewport_x + r_newrefdef.x,
+				gl3_viewport_y + vid.height - r_newrefdef.height - r_newrefdef.y,
 				r_newrefdef.width, r_newrefdef.height);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 		GL3_ResetClearColor();
@@ -1365,9 +1416,9 @@ static void
 GL3_SetGL2D(void)
 {
 	int x = 0;
-	int w = vid.width;
+	int w = gl3_viewport_width;
 	int y = 0;
-	int h = vid.height;
+	int h = gl3_viewport_height;
 
 #if 0 // TODO: stereo
 	/* set 2D virtual screen size */
@@ -1386,7 +1437,7 @@ GL3_SetGL2D(void)
 	}
 #endif // 0
 
-	glViewport(x, y, w, h);
+	glViewport(gl3_viewport_x + x, gl3_viewport_y + y, w, h);
 
 	hmm_mat4 transMatr = HMM_Orthographic(0, vid.width, vid.height, 0, -99999, 99999);
 
@@ -1553,11 +1604,11 @@ SetupGL(void)
 
 		GL3_Clear(); // clear the FBO that's bound now
 
-		glViewport(0, 0, w, h); // this will be moved to the center later, so no x/y offset
+		glViewport(0, 0, w, h); // FBO coordinates have no drawable offset.
 	}
 	else // rendering directly (not to FBO for postprocessing)
 	{
-		glViewport(x, y2, w, h);
+		glViewport(gl3_viewport_x + x, gl3_viewport_y + y2, w, h);
 	}
 
 	/* set up projection matrix (eye coordinates -> clip coordinates) */
@@ -2057,6 +2108,9 @@ GL3_BeginFrame(float camera_separation)
 		GL3_RecreateShaders();
 	}
 
+
+	GL3_UpdateViewport();
+	GL3_ClearViewportBars();
 
 	/* go into 2D mode */
 

--- a/src/client/refresh/gl4/gl4_main.c
+++ b/src/client/refresh/gl4/gl4_main.c
@@ -61,6 +61,13 @@ vec3_t gl4_origin;
 
 int c_brush_polys, c_alias_polys;
 
+static int gl4_drawable_width;
+static int gl4_drawable_height;
+static int gl4_viewport_x;
+static int gl4_viewport_y;
+static int gl4_viewport_width;
+static int gl4_viewport_height;
+
 static float v_blend[4]; /* final blending color */
 
 const hmm_mat4 gl4_identityMat4 = {{
@@ -90,6 +97,52 @@ cvar_t *gl_nobind;
 cvar_t *gl_finish;
 cvar_t *gl4_debugcontext;
 cvar_t *gl4_usefbo;
+
+static void GL4_ResetClearColor(void);
+
+static void
+GL4_UpdateViewport(void)
+{
+	gl4_drawable_width = vid.width;
+	gl4_drawable_height = vid.height;
+	GL4_GetDrawableSize(&gl4_drawable_width, &gl4_drawable_height);
+
+	if (gl4_drawable_width <= 0)
+	{
+		gl4_drawable_width = vid.width;
+	}
+
+	if (gl4_drawable_height <= 0)
+	{
+		gl4_drawable_height = vid.height;
+	}
+
+	gl4_viewport_x = gl4_drawable_width > vid.width ?
+		(gl4_drawable_width - vid.width) / 2 : 0;
+	gl4_viewport_y = gl4_drawable_height > vid.height ?
+		(gl4_drawable_height - vid.height) / 2 : 0;
+	gl4_viewport_width = gl4_drawable_width < vid.width ?
+		gl4_drawable_width : vid.width;
+	gl4_viewport_height = gl4_drawable_height < vid.height ?
+		gl4_drawable_height : vid.height;
+}
+
+static void
+GL4_ClearViewportBars(void)
+{
+	if (gl4_viewport_x == 0 && gl4_viewport_y == 0 &&
+		gl4_viewport_width == gl4_drawable_width &&
+		gl4_viewport_height == gl4_drawable_height)
+	{
+		return;
+	}
+
+	glDisable(GL_SCISSOR_TEST);
+	glViewport(0, 0, gl4_drawable_width, gl4_drawable_height);
+	glClearColor(0, 0, 0, 1);
+	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+	GL4_ResetClearColor();
+}
 
 DA_TYPEDEF(mvtx_t, Vtx3DArray_t);
 DA_TYPEDEF(GLushort, UShortArray_t);
@@ -1330,8 +1383,8 @@ SetupFrame(void)
 	{
 		glEnable(GL_SCISSOR_TEST);
 		glClearColor(0.3, 0.3, 0.3, 1);
-		glScissor(r_newrefdef.x,
-				vid.height - r_newrefdef.height - r_newrefdef.y,
+		glScissor(gl4_viewport_x + r_newrefdef.x,
+				gl4_viewport_y + vid.height - r_newrefdef.height - r_newrefdef.y,
 				r_newrefdef.width, r_newrefdef.height);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 		glClearColor(1, 0, 0.5, 0.5);
@@ -1343,9 +1396,9 @@ static void
 GL4_SetGL2D(void)
 {
 	int x = 0;
-	int w = vid.width;
+	int w = gl4_viewport_width;
 	int y = 0;
-	int h = vid.height;
+	int h = gl4_viewport_height;
 
 #if 0 // TODO: stereo
 	/* set 2D virtual screen size */
@@ -1364,7 +1417,7 @@ GL4_SetGL2D(void)
 	}
 #endif // 0
 
-	glViewport(x, y, w, h);
+	glViewport(gl4_viewport_x + x, gl4_viewport_y + y, w, h);
 
 	hmm_mat4 transMatr = HMM_Orthographic(0, vid.width, vid.height, 0, -99999, 99999);
 
@@ -1531,11 +1584,11 @@ SetupGL(void)
 
 		GL4_Clear(); // clear the FBO that's bound now
 
-		glViewport(0, 0, w, h); // this will be moved to the center later, so no x/y offset
+		glViewport(0, 0, w, h); // FBO coordinates have no drawable offset.
 	}
 	else // rendering directly (not to FBO for postprocessing)
 	{
-		glViewport(x, y2, w, h);
+		glViewport(gl4_viewport_x + x, gl4_viewport_y + y2, w, h);
 	}
 
 	/* set up projection matrix (eye coordinates -> clip coordinates) */
@@ -2034,6 +2087,9 @@ GL4_BeginFrame(float camera_separation)
 		GL4_RecreateShaders();
 	}
 
+
+	GL4_UpdateViewport();
+	GL4_ClearViewportBars();
 
 	/* go into 2D mode */
 

--- a/src/client/vid/glimp_sdl2.c
+++ b/src/client/vid/glimp_sdl2.c
@@ -793,6 +793,10 @@ GLimp_GetDesktopMode(int *pwidth, int *pheight)
 		last_display = SDL_GetWindowDisplayIndex(window);
 		SDL_GetWindowPosition(window, &last_position_x, &last_position_y);
 	}
+	else
+	{
+		last_display = (int)vid_displayindex->value;
+	}
 
 	if (last_display < 0)
 	{
@@ -801,7 +805,7 @@ GLimp_GetDesktopMode(int *pwidth, int *pheight)
 		last_display = 0;
 	}
 
-	// We can't get desktop where we start, so use first desktop
+	// Use the current or selected display mode.
 	if(SDL_GetCurrentDisplayMode(last_display, &mode) != 0)
 	{
 		// In case of error...

--- a/src/client/vid/glimp_sdl3.c
+++ b/src/client/vid/glimp_sdl3.c
@@ -879,34 +879,12 @@ GLimp_GetDesktopMode(int *pwidth, int *pheight)
 		   by passing the mode and not the geometry from
 		   the renderer to GLimp_InitGraphics(), however
 		   that would break the renderer API. */
-		SDL_DisplayID current = SDL_GetPrimaryDisplay();
-
-		if (current == 0)
-		{
-			last_display = 0;
-		}
-		else
-		{
-			last_display = GetDisplayIndex(current);
-		}
+		last_display = GetSelectedDisplayIndex();
 	}
 	else
 	{
 		/* save current display as default */
-		SDL_DisplayID current = SDL_GetDisplayForWindow(window);
-
-		if (current == 0)
-		{
-			/* There are some obscure setups were SDL is
-			   unable to get the current display,one X11
-			   server with several screen is one of these,
-			   so add a fallback to the first display. */
-			last_display = 0;
-		}
-		else
-		{
-			last_display = GetDisplayIndex(current);
-		}
+		last_display = GetDisplayIndex(GetWindowDisplayID());
 
 		SDL_GetWindowPosition(window, &last_position_x, &last_position_y);
 	}

--- a/src/client/vid/glimp_sdl3.c
+++ b/src/client/vid/glimp_sdl3.c
@@ -118,6 +118,161 @@ ClearDisplayIndices(void)
 	SDL_free(displays);
 }
 
+static int GetFullscreenType(void);
+
+static qboolean
+FullscreenModeMatches(const SDL_DisplayMode *actual,
+		const SDL_DisplayMode *requested)
+{
+	return actual != NULL && requested != NULL &&
+		actual->displayID == requested->displayID &&
+		actual->format == requested->format &&
+		actual->w == requested->w && actual->h == requested->h &&
+		actual->pixel_density == requested->pixel_density &&
+		actual->refresh_rate == requested->refresh_rate &&
+		actual->refresh_rate_numerator == requested->refresh_rate_numerator &&
+		actual->refresh_rate_denominator == requested->refresh_rate_denominator;
+}
+
+static qboolean
+FullscreenStateMatches(int fullscreen, SDL_DisplayID display,
+		const SDL_DisplayMode *requestedMode)
+{
+	if (fullscreen == FULLSCREEN_OFF)
+	{
+		return !(SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN);
+	}
+
+	if (!(SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN) ||
+			SDL_GetDisplayForWindow(window) != display)
+	{
+		return false;
+	}
+
+	const SDL_DisplayMode *actualMode = SDL_GetWindowFullscreenMode(window);
+
+	if (fullscreen == FULLSCREEN_DESKTOP)
+	{
+		return actualMode == NULL;
+	}
+
+	return FullscreenModeMatches(actualMode, requestedMode);
+}
+
+static qboolean
+SyncWindowFullscreen(int fullscreen, SDL_DisplayID display,
+		const SDL_DisplayMode *requestedMode, const char *action)
+{
+	SDL_ClearError();
+
+	if (SDL_SyncWindow(window))
+	{
+		return true;
+	}
+
+	if (!FullscreenStateMatches(fullscreen, display, requestedMode))
+	{
+		Com_Printf("Couldn't synchronize %s fullscreen: requested state was not reached\n",
+				action);
+		SDL_ClearError();
+		return false;
+	}
+
+	Com_Printf("WARNING: SDL timed out synchronizing %s fullscreen; requested state verified.\n",
+			action);
+	SDL_ClearError();
+	return true;
+}
+
+static qboolean
+SetWindowFullscreen(int fullscreen, int w, int h)
+{
+	SDL_DisplayID display = SDL_GetDisplayForWindow(window);
+	SDL_DisplayMode closestMode;
+	const SDL_DisplayMode *requestedMode = NULL;
+
+	if (display == 0)
+	{
+		display = displays[last_display];
+	}
+	else
+	{
+		last_display = GetDisplayIndex(display);
+	}
+
+	if (GetFullscreenType() != FULLSCREEN_OFF)
+	{
+		if (!SDL_SetWindowFullscreen(window, false))
+		{
+			Com_Printf("Couldn't leave fullscreen: %s\n", SDL_GetError());
+			return false;
+		}
+
+		if (!SyncWindowFullscreen(FULLSCREEN_OFF, display, NULL, "leaving"))
+		{
+			return false;
+		}
+	}
+
+	if (fullscreen == FULLSCREEN_OFF)
+	{
+		return true;
+	}
+
+	if (fullscreen == FULLSCREEN_DESKTOP)
+	{
+		if (!SDL_SetWindowFullscreenMode(window, NULL))
+		{
+			Com_Printf("Couldn't set desktop fullscreen mode: %s\n", SDL_GetError());
+			return false;
+		}
+	}
+	else
+	{
+		if (vid_rate->value > 0 &&
+				!SDL_GetClosestFullscreenDisplayMode(display, w, h,
+						vid_rate->value, true, &closestMode))
+		{
+			Com_Printf("SDL was unable to find a mode close to %ix%i@%f\n", w, h, vid_rate->value);
+			Com_Printf("Retrying with desktop refresh rate\n");
+			Cvar_SetValue("vid_rate", -1);
+		}
+
+		if (vid_rate->value <= 0 &&
+				!SDL_GetClosestFullscreenDisplayMode(display, w, h,
+						0, true, &closestMode))
+		{
+			Com_Printf("SDL was unable to find a mode close to %ix%i@0\n", w, h);
+			return false;
+		}
+
+		Com_Printf("User requested %ix%i@%f, setting closest mode %ix%i@%f\n",
+				w, h, vid_rate->value, closestMode.w, closestMode.h,
+				closestMode.refresh_rate);
+
+		if (!SDL_SetWindowFullscreenMode(window, &closestMode))
+		{
+			Com_Printf("Couldn't set closest mode: %s\n", SDL_GetError());
+			return false;
+		}
+
+		requestedMode = &closestMode;
+	}
+
+	if (!SDL_SetWindowFullscreen(window, true))
+	{
+		Com_Printf("Couldn't enter fullscreen: %s\n", SDL_GetError());
+		return false;
+	}
+
+	if (!SyncWindowFullscreen(fullscreen, display, requestedMode, "entering"))
+	{
+		return false;
+	}
+
+	return true;
+}
+
 static qboolean
 CreateSDLWindow(SDL_WindowFlags flags, int fullscreen, int w, int h)
 {
@@ -141,7 +296,8 @@ CreateSDLWindow(SDL_WindowFlags flags, int fullscreen, int w, int h)
 	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_Y_NUMBER, last_position_y);
 	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, w);
 	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, h);
-	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_FLAGS_NUMBER, flags);
+	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_FLAGS_NUMBER,
+			flags & ~SDL_WINDOW_FULLSCREEN);
 
 	window = SDL_CreateWindowWithProperties(props);
 	SDL_DestroyProperties(props);
@@ -166,83 +322,11 @@ CreateSDLWindow(SDL_WindowFlags flags, int fullscreen, int w, int h)
 		{
 			last_display = GetDisplayIndex(current);
 		}
-
-		/* Set requested fullscreen mode. */
-		if (flags & SDL_WINDOW_FULLSCREEN)
-		{
-            /* SDLs behavior changed between SDL 2 and SDL 3: In SDL 2
-			   the fullscreen window could be set with whatever mode
-			   was requested. In SDL 3 the fullscreen window is always
-			   created at desktop resolution. If a fullscreen window
-			   is requested, we can't do anything else and are done here. */
-			if (fullscreen == FULLSCREEN_DESKTOP)
-			{
-				return true;
-			}
-
-			/* Otherwise try to find a mode near the requested one and
-			   switch to it in exclusive fullscreen mode. */
-			SDL_DisplayMode closestMode;
-
-			if (vid_rate->value > 0)
-			{
-				if (SDL_GetClosestFullscreenDisplayMode(displays[last_display], w, h, vid_rate->value, true, &closestMode) != true)
-				{
-					Com_Printf("SDL was unable to find a mode close to %ix%i@%f\n", w, h, vid_rate->value);
-					Com_Printf("Retrying with desktop refresh rate\n");
-
-					/* This is likely pointless. SDL3 walks the complete mode list
-					   when trying to find a matching mode. If it didn't find a
-					   refresh rate above something is very wrong it won't find
-					   one here either. */
-					if (SDL_GetClosestFullscreenDisplayMode(displays[last_display], w, h, 0, true, &closestMode) == true)
-					{
-						Cvar_SetValue("vid_rate", -1);
-					}
-					else
-					{
-						Com_Printf("SDL was unable to find a mode close to %ix%i@0\n", w, h);
-						return false;
-					}
-				}
-			}
-			else
-			{
-				if (SDL_GetClosestFullscreenDisplayMode(displays[last_display], w, h, 0, true, &closestMode) != true)
-				{
-					Com_Printf("SDL was unable to find a mode close to %ix%i@0\n", w, h);
-					return false;
-				}
-			}
-
-			Com_Printf("User requested %ix%i@%f, setting closest mode %ix%i@%f\n",
-					w, h, vid_rate->value, closestMode.w, closestMode.h , closestMode.refresh_rate);
-
-
-			/* TODO SDL3: Same code is in InitGraphics(), refactor into
-			 * a function? */
-			if (!SDL_SetWindowFullscreenMode(window, &closestMode))
-			{
-				Com_Printf("Couldn't set closest mode: %s\n", SDL_GetError());
-				return false;
-			}
-
-			if (!SDL_SetWindowFullscreen(window, true))
-			{
-				Com_Printf("Couldn't switch to exclusive fullscreen: %s\n", SDL_GetError());
-				return false;
-			}
-
-			if (!SDL_SyncWindow(window))
-			{
-				Com_Printf("Couldn't synchronize window state: %s\n", SDL_GetError());
-				return false;
-			}
-		}
 	}
 	else
 	{
-		Com_Printf("Creating window failed: %s\n", SDL_GetError());
+		Com_Printf("Creating window failed for %ix%i, fullscreen %i, flags 0x%llx: %s\n",
+				w, h, fullscreen, (unsigned long long)flags, SDL_GetError());
 		return false;
 	}
 
@@ -556,67 +640,21 @@ GLimp_InitGraphics(int fullscreen, int *pwidth, int *pheight)
 	if (initSuccessful && GetWindowSize(&curWidth, &curHeight)
 			&& (curWidth == width) && (curHeight == height))
 	{
-		SDL_DisplayMode closestMode;
+		int currentFullscreen = GetFullscreenType();
 
-
-		/* If we want fullscreen, but aren't */
-		if (GetFullscreenType())
+		if (currentFullscreen != fullscreen)
 		{
-			if (fullscreen == FULLSCREEN_EXCLUSIVE)
+			if (!SetWindowFullscreen(fullscreen, width, height))
 			{
-				if (SDL_GetClosestFullscreenDisplayMode(displays[last_display], width, height, vid_rate->value, false, &closestMode) != true)
-				{
-					Com_Printf("SDL was unable to find a mode close to %ix%i@%f\n", width, height, vid_rate->value);
-
-					if (vid_rate->value != 0)
-					{
-						Com_Printf("Retrying with desktop refresh rate\n");
-
-						if (SDL_GetClosestFullscreenDisplayMode(displays[last_display], width, height, 0, false, &closestMode) == true)
-						{
-							Cvar_SetValue("vid_rate", 0);
-						}
-						else
-						{
-							Com_Printf("SDL was unable to find a mode close to %ix%i@0\n", width, height);
-							return false;
-						}
-					}
-				}
-			}
-			else if (fullscreen == FULLSCREEN_DESKTOP)
-			{
-				/* Fullscreen window */
-				/* closestMode = NULL; */
-			}
-
-			if (!SDL_SetWindowFullscreenMode(window, &closestMode))
-			{
-				Com_Printf("Couldn't set fullscreen modmode: %s\n", SDL_GetError());
+				Com_Printf("SDL fullscreen transition failed.\n");
 				Cvar_SetValue("vid_fullscreen", 0);
-			}
-			else
-			{
-				if (!SDL_SetWindowFullscreen(window, true))
-				{
-					Com_Printf("Couldn't switch to exclusive fullscreen: %s\n", SDL_GetError());
-					Cvar_SetValue("vid_fullscreen", 0);
-				}
-				else
-				{
-					if (!SDL_SyncWindow(window))
-					{
-						Com_Printf("Couldn't synchronize window state: %s\n", SDL_GetError());
-						Cvar_SetValue("vid_fullscreen", 0);
-					}
-				}
+				return false;
 			}
 
 			Cvar_SetValue("vid_fullscreen", fullscreen);
 		}
 
-		/* Are we now? */
-		if (GetFullscreenType())
+		if (GetFullscreenType() == fullscreen)
 		{
 			return true;
 		}
@@ -675,7 +713,7 @@ GLimp_InitGraphics(int fullscreen, int *pwidth, int *pheight)
 
 				Com_Printf("SDL SetVideoMode failed: %s\n", SDL_GetError());
 				Com_Printf("Reverting to %s r_mode %i (%ix%i) with %dx MSAA.\n",
-					        (flags & fs_flag) ? "fullscreen" : "windowed",
+				        fullscreen != FULLSCREEN_OFF ? "fullscreen" : "windowed",
 					        (int) Cvar_VariableValue("r_mode"), width, height,
 					        msaa_samples);
 
@@ -716,6 +754,21 @@ GLimp_InitGraphics(int fullscreen, int *pwidth, int *pheight)
 
 	last_flags = flags;
 
+	/* Initialize the rendering context before entering fullscreen. Cocoa can
+	 * reject an OpenGL window when fullscreen is requested at creation. */
+	if (!re.InitContext(window))
+	{
+		return false;
+	}
+
+	if (!SetWindowFullscreen(fullscreen, width, height))
+	{
+		Com_Printf("SDL fullscreen transition failed.\n");
+		re.ShutdownContext();
+		ShutdownGraphics();
+		return false;
+	}
+
 	/* Now that we've got a working window print it's mode. */
 	int curdisplay;
 	if ((curdisplay = SDL_GetDisplayForWindow(window)) == 0)
@@ -735,14 +788,6 @@ GLimp_InitGraphics(int fullscreen, int *pwidth, int *pheight)
 	else
 	{
 		Com_Printf("Real display mode: %ix%i@%.2f\n", mode->w, mode->h, mode->refresh_rate);
-	}
-
-
-    /* Initialize rendering context. */
-	if (!re.InitContext(window))
-	{
-		/* InitContext() should have logged an error. */
-		return false;
 	}
 
 	/* We need the actual drawable size for things like the

--- a/src/client/vid/glimp_sdl3.c
+++ b/src/client/vid/glimp_sdl3.c
@@ -80,7 +80,7 @@ GetDisplayIndex(SDL_DisplayID displayid)
 		}
 	}
 
-	return 0;
+	return vid_displayindex ? (int)vid_displayindex->value : 0;
 }
 
 /*
@@ -101,6 +101,26 @@ ClampDisplayIndexCvar(void)
 	}
 }
 
+static int
+GetSelectedDisplayIndex(void)
+{
+	return (int)vid_displayindex->value;
+}
+
+static SDL_DisplayID
+GetSelectedDisplayID(void)
+{
+	return displays[GetSelectedDisplayIndex()];
+}
+
+static SDL_DisplayID
+GetWindowDisplayID(void)
+{
+	SDL_DisplayID display = window ? SDL_GetDisplayForWindow(window) : 0;
+
+	return display != 0 ? display : GetSelectedDisplayID();
+}
+
 static void
 ClearDisplayIndices(void)
 {
@@ -116,6 +136,8 @@ ClearDisplayIndices(void)
 	}
 
 	SDL_free(displays);
+	displays = NULL;
+	num_displays = 0;
 }
 
 static int GetFullscreenType(void);
@@ -187,18 +209,10 @@ SyncWindowFullscreen(int fullscreen, SDL_DisplayID display,
 static qboolean
 SetWindowFullscreen(int fullscreen, int w, int h)
 {
-	SDL_DisplayID display = SDL_GetDisplayForWindow(window);
+	SDL_DisplayID display = GetWindowDisplayID();
 	SDL_DisplayMode closestMode;
 	const SDL_DisplayMode *requestedMode = NULL;
-
-	if (display == 0)
-	{
-		display = displays[last_display];
-	}
-	else
-	{
-		last_display = GetDisplayIndex(display);
-	}
+	last_display = GetDisplayIndex(display);
 
 	if (GetFullscreenType() != FULLSCREEN_OFF)
 	{
@@ -278,7 +292,8 @@ CreateSDLWindow(SDL_WindowFlags flags, int fullscreen, int w, int h)
 {
 	if (SDL_WINDOWPOS_ISUNDEFINED(last_position_x) || SDL_WINDOWPOS_ISUNDEFINED(last_position_y) || last_position_x < 0 ||last_position_y < 24)
 	{
-		last_position_x = last_position_y = SDL_WINDOWPOS_UNDEFINED_DISPLAY(displays[(int)vid_displayindex->value]);
+		last_position_x = last_position_y = SDL_WINDOWPOS_UNDEFINED_DISPLAY(
+			GetSelectedDisplayID());
 	}
 
 	/* Force the window to minimize when focus is lost. This was the
@@ -308,20 +323,7 @@ CreateSDLWindow(SDL_WindowFlags flags, int fullscreen, int w, int h)
 		SDL_StartTextInput(window);
 
 		/* save current display as default */
-		SDL_DisplayID current = SDL_GetDisplayForWindow(window);
-
-		if (current == 0)
-		{
-			/* There are some obscure setups were SDL is
-			   unable to get the current display,one X11
-			   server with several screen is one of these,
-			   so add a fallback to the first display. */
-			last_display = 0;
-		}
-		else
-		{
-			last_display = GetDisplayIndex(current);
-		}
+		last_display = GetDisplayIndex(GetWindowDisplayID());
 	}
 	else
 	{
@@ -377,28 +379,7 @@ GetWindowSize(int* w, int* h)
 static void
 PrintDisplayModes(void)
 {
-	int curdisplay;
-
-	if (window == NULL)
-	{
-		/* Called without a windows, list modes
-		   from the first display. This is the
-		   primary display and likely the one the
-		   game will run on. */
-		curdisplay = SDL_GetPrimaryDisplay();
-	}
-	else
-	{
-		/* Otherwise use the display were the window
-		   is displayed. There are some obscure
-		   setups were this can fail - one X11 server
-		   with several screen is one of these - so
-		   add a fallback to the first display. */
-		if ((curdisplay = SDL_GetDisplayForWindow(window)) == 0)
-		{
-			curdisplay = SDL_GetPrimaryDisplay();
-		}
-	}
+	SDL_DisplayID curdisplay = GetWindowDisplayID();
 
 	int nummodes = 0;
 	SDL_DisplayMode **modes = SDL_GetFullscreenDisplayModes(curdisplay, &nummodes);
@@ -464,25 +445,12 @@ ShutdownGraphics(void)
 	if (window)
 	{
 		/* save current display as default */
-		SDL_DisplayID current = SDL_GetDisplayForWindow(window);
-
-		if (current == 0)
-		{
-			/* There are some obscure setups were SDL is
-			   unable to get the current display,one X11
-			   server with several screen is one of these,
-			   so add a fallback to the first display. */
-			last_display = 0;
-		}
-		else
-		{
-			last_display = GetDisplayIndex(current);
-		}
+		last_display = GetDisplayIndex(GetWindowDisplayID());
 
 		/* or if current display isn't the desired default */
-		if (last_display != displays[(int)vid_displayindex->value]) {
+		if (last_display != GetSelectedDisplayIndex()) {
 			last_position_x = last_position_y = SDL_WINDOWPOS_UNDEFINED;
-			last_display = displays[(int)vid_displayindex->value];
+			last_display = GetSelectedDisplayIndex();
 		}
 		else {
 			SDL_GetWindowPosition(window, &last_position_x, &last_position_y);
@@ -559,7 +527,7 @@ GLimp_Init(void)
 
 				Com_sprintf(displayindices[ i ], 11, "%d", i);
 
-				Com_Printf(" - %d\n", displays[i]);
+				Com_Printf(" - %u\n", (unsigned)displays[i]);
 			}
 
 			/* The last entry is NULL to indicate the list of strings ends. */
@@ -640,6 +608,8 @@ GLimp_InitGraphics(int fullscreen, int *pwidth, int *pheight)
 	if (initSuccessful && GetWindowSize(&curWidth, &curHeight)
 			&& (curWidth == width) && (curHeight == height))
 	{
+		last_display = GetDisplayIndex(GetWindowDisplayID());
+
 		int currentFullscreen = GetFullscreenType();
 
 		if (currentFullscreen != fullscreen)
@@ -770,15 +740,7 @@ GLimp_InitGraphics(int fullscreen, int *pwidth, int *pheight)
 	}
 
 	/* Now that we've got a working window print it's mode. */
-	int curdisplay;
-	if ((curdisplay = SDL_GetDisplayForWindow(window)) == 0)
-	{
-		/* There are some obscure setups were SDL is
-		   unable to get the current display,one X11
-		   server with several screen is one of these,
-		   so add a fallback to the first display. */
-		curdisplay = SDL_GetPrimaryDisplay();
-	}
+	SDL_DisplayID curdisplay = GetWindowDisplayID();
 
 	const SDL_DisplayMode *mode;
 	if ((mode = SDL_GetCurrentDisplayMode(curdisplay)) == NULL)
@@ -889,28 +851,7 @@ GLimp_GetRefreshRate(void)
 	else if (glimp_refreshRate == -1)
 	{
 		const SDL_DisplayMode *mode;
-		int curdisplay;
-
-		if (window == NULL)
-		{
-			/* This is paranoia. This function should only be
-			   called if there is a working window. Otherwise
-			   things will likely break somewhere else in the
-			   client. */
-			curdisplay = SDL_GetPrimaryDisplay();
-		}
-		else
-		{
-			if ((curdisplay = SDL_GetDisplayForWindow(window)) == 0)
-			{
-				/* There are some obscure setups were SDL is
-				   unable to get the current display,one X11
-				   server with several screen is one of these,
-				   so add a fallback to the first display. */
-				curdisplay = SDL_GetPrimaryDisplay();
-			}
-
-		}
+		SDL_DisplayID curdisplay = GetWindowDisplayID();
 
 		if ((mode = SDL_GetCurrentDisplayMode(curdisplay)) == NULL)
 		{

--- a/src/client/vid/vid.c
+++ b/src/client/vid/vid.c
@@ -333,6 +333,17 @@ VID_GetRendererLibPath(const char *renderer, char *path, size_t len)
 qboolean
 VID_HasRenderer(const char *renderer)
 {
+	/* SDL's Cocoa video backend has no OpenGL ES context support. Do not
+	 * advertise renderers that can never initialize on macOS, otherwise the
+	 * renderer fallback enters GLimp_InitGraphics() and resets the user's
+	 * video settings before it can try desktop OpenGL. */
+#ifdef __APPLE__
+	if (Q_stricmp(renderer, "gles1") == 0 || Q_stricmp(renderer, "gles3") == 0)
+	{
+		return false;
+	}
+#endif
+
 	char reflib_path[MAX_OSPATH] = {0};
 	VID_GetRendererLibPath(renderer, reflib_path, sizeof(reflib_path));
 


### PR DESCRIPTION
## Summary

Fix SDL3 fullscreen initialization and transitions on macOS, where Cocoa can reject an OpenGL window if `SDL_WINDOW_FULLSCREEN` is passed during window creation. The window is created without that flag, then switched to the requested fullscreen mode after the OpenGL context exists.

The same transition path handles windowed, desktop fullscreen, and exclusive fullscreen modes. Display selection remains consistent during window creation, mode changes, and shutdown.

## Renderer and viewport handling

GLES1 and GLES3 are excluded from the renderer list on macOS because the Cocoa backend does not provide the required OpenGL ES context. Requests for those renderers therefore fall back to a supported renderer.

GL1, GL3, and GL4 use the actual drawable size when calculating the viewport. Fixed-resolution rendering is centered in the drawable, and the corresponding offsets are applied to 3D rendering, scissor operations, and 2D rendering. Letterbox bars are cleared when present.

## Testing

The SDL2 and SDL3 clients and their GL1, GL3, and GL4 renderers built successfully. The renderer builds also passed with compiler warnings treated as errors.

Runtime testing was limited to macOS on an Apple M3 with Cocoa and SDL 3.4.14 using two displays. GL1, GL3, and GL4 loaded `base1` in exclusive fullscreen on both displays. GL4 also passed native-fullscreen and windowed-to-exclusive transitions on both displays. All ten runs exited cleanly, left the non-target display dimensions unchanged, and restored both displays exactly.

A windowed baseline and fullscreen screenshots were captured. A separate 5120x2880 high-DPI GL4 capture contained a centered 5120x2160 image with equal 360-pixel black bars above and below.

Windows, Linux, other GPUs, SDL2 runtime behavior, moving the window between displays during runtime, CI, and reference-image pixel comparison were not tested.

AI-generated with OpenAI Codex. Models: gpt-5.6-sol and gpt-5.6-luna xhigh.
