### PR TITLE
vk: honour vk_postprocess and drop vk_pixel_size from the tile clear

### DIFF
--- a/src/client/refresh/vk/header/local.h
+++ b/src/client/refresh/vk/header/local.h
@@ -111,6 +111,7 @@ extern  cvar_t  *vk_molten_fastmath;
 extern  cvar_t  *vk_molten_metalbuffers;
 #endif
 extern	cvar_t	*vk_pixel_size;
+extern       cvar_t  *vk_postprocess;
 
 extern	int		c_visible_textures;
 

--- a/src/client/refresh/vk/vk_common.c
+++ b/src/client/refresh/vk/vk_common.c
@@ -3297,10 +3297,12 @@ QVk_BindPipeline(qvkpipeline_t *pipeline)
 		vkCmdBindPipeline(vk_activeCmdbuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline->pl);
 		vk_state.current_pipeline = pipeline->pl;
 
-		/* binding a pipeline invalidates the push constants, so the world
-		   shaders get told after every bind whether they have to do the work
-		   the postprocess pass would otherwise do for them */
+		/* the bind is the only place that knows the current renderpass, so
+		   the world shaders get told here whether they have to do the work
+		   the postprocess pass would otherwise do for them, which includes
+		   honouring vk_postprocess the way that pass does */
 		postConstants[0] = (vk_worldDirectRender &&
+			vk_postprocess->value &&
 			vk_state.current_renderpass == RP_WORLD) ? 1.0f : 0.0f;
 		postConstants[1] = 2.1f - vid_gamma->value;
 

--- a/src/client/refresh/vk/vk_draw.c
+++ b/src/client/refresh/vk/vk_draw.c
@@ -302,7 +302,7 @@ RE_Draw_PicScaledCol(int x, int y, const char *name, float factor, const vec3_t 
 void
 RE_Draw_TileClear(int x, int y, int w, int h, const char *name)
 {
-	float divisor, full_uv_w, full_uv_h;
+	float full_uv_w, full_uv_h;
 	int x2, base_w, base_h;
 	const image_t *image;
 
@@ -339,8 +339,6 @@ RE_Draw_TileClear(int x, int y, int w, int h, const char *name)
 	vkCmdSetViewport(vk_activeCmdbuffer, 0u, 1u, &tileViewport);
 	vkCmdSetScissor(vk_activeCmdbuffer, 0u, 1u, &tileScissor);
 
-	divisor = (vk_pixel_size->value < 1.0f ? 1.0f : vk_pixel_size->value);
-
 	base_w = image->upload_width;
 	base_h = image->upload_height;
 
@@ -349,27 +347,25 @@ RE_Draw_TileClear(int x, int y, int w, int h, const char *name)
 
 	for (x2 = 0; x2 < w; x2 += base_w)
 	{
-		float tile_uv_w, tile_div_w;
+		float tile_uv_w;
 		int tile_base_w, y2;
 
 		tile_base_w = (x2 + base_w > w) ? (w - x2) : base_w;
 
 		tile_uv_w = full_uv_w * ((float)tile_base_w / base_w);
-		tile_div_w = tile_base_w * divisor;
 
 		for (y2 = 0; y2 < h; y2 += base_h)
 		{
-			float tile_uv_h, tile_div_h;
+			float tile_uv_h;
 			int tile_base_h;
 
 			tile_base_h = (y2 + base_h > h) ? (h - y2) : base_h;
 			tile_uv_h = full_uv_h * ((float)tile_base_h / base_h);
-			tile_div_h = tile_base_h * divisor;
 
-			QVk_DrawTexRect((float)(x + x2 * divisor) / vid.width,
-							(float)(y + y2 * divisor) / vid.height,
-							tile_div_w / vid.width,
-							tile_div_h / vid.height,
+			QVk_DrawTexRect((float)(x + x2) / vid.width,
+							(float)(y + y2) / vid.height,
+							(float)tile_base_w / vid.width,
+							(float)tile_base_h / vid.height,
 							image->sl, image->tl,
 							tile_uv_w, tile_uv_h,
 							&image->vk_texture);


### PR DESCRIPTION
QVk_BindPipeline turned the world shader gamma and intensity bump on from vk_worldDirectRender alone, so the cvar the postprocess pass it replaces honoured stopped working on the direct path. RE_Draw_TileClear scaled tile extents by vk_pixel_size, which only ever applies to the world viewport, so the border overran the view.