### PR TITLE
renders: skip the prefix walk for pic names that resolve nowhere

### DIFF
--- a/src/client/refresh/files/stb.c
+++ b/src/client/refresh/files/stb.c
@@ -945,6 +945,7 @@ typedef struct
 typedef struct
 {
 	char name[MAX_QPATH];
+	qboolean warned;
 } picignore_t;
 
 static piccache_t pic_cache[PIC_CACHE_SIZE];
@@ -977,15 +978,18 @@ R_PicIgnored(const char *name)
 	picignore_t *ignore;
 
 	ignore = pic_ignore + R_PicCacheSlot(name);
-	if (!strcmp(ignore->name, name))
+	if (strcmp(ignore->name, name))
+	{
+		Q_strlcpy(ignore->name, name, sizeof(ignore->name));
+		ignore->warned = false;
+	}
+
+	if (ignore->warned)
 	{
 		return true;
 	}
 
-	if (!ignore->name[0])
-	{
-		Q_strlcpy(ignore->name, name, sizeof(ignore->name));
-	}
+	ignore->warned = true;
 
 	return false;
 }
@@ -1001,8 +1005,12 @@ R_FindPic(const char *name, findimage_t find_image)
 		char	namewe[MAX_QPATH];
 		const char* ext;
 		piccache_t *cache;
+		picignore_t *ignore;
+		uint32_t slot;
 
-		cache = pic_cache + R_PicCacheSlot(name);
+		slot = R_PicCacheSlot(name);
+		cache = pic_cache + slot;
+		ignore = pic_ignore + slot;
 
 		if (!strcmp(cache->name, name))
 		{
@@ -1012,6 +1020,11 @@ R_FindPic(const char *name, findimage_t find_image)
 			{
 				return image;
 			}
+		}
+
+		if (!strcmp(ignore->name, name))
+		{
+			return NULL;
 		}
 
 		ext = COM_FileExtension(name);
@@ -1066,9 +1079,15 @@ R_FindPic(const char *name, findimage_t find_image)
 			Q_strlcpy(cache->name, name, sizeof(cache->name));
 			Q_strlcpy(cache->path, pathname, sizeof(cache->path));
 		}
-		else if (!strcmp(cache->name, name))
+		else
 		{
-			cache->name[0] = 0;
+			if (!strcmp(cache->name, name))
+			{
+				cache->name[0] = 0;
+			}
+
+			Q_strlcpy(ignore->name, name, sizeof(ignore->name));
+			ignore->warned = false;
 		}
 	}
 	else

--- a/src/client/refresh/gl1/gl1_model.c
+++ b/src/client/refresh/gl1/gl1_model.c
@@ -453,6 +453,8 @@ RI_BeginRegistration(const char *model)
 	registration_sequence++;
 	r_oldviewcluster = -1; /* force markleafs */
 
+	R_PicPathCacheClean();
+
 	Com_sprintf(fullname, sizeof(fullname), "maps/%s.bsp", model);
 
 	/* explicitly free the old map if different

--- a/src/client/refresh/gl3/gl3_model.c
+++ b/src/client/refresh/gl3/gl3_model.c
@@ -453,6 +453,8 @@ GL3_BeginRegistration(const char *model)
 	registration_sequence++;
 	r_oldviewcluster = -1; /* force markleafs */
 
+	R_PicPathCacheClean();
+
 	gl3state.currentlightmap = -1;
 
 	Com_sprintf(fullname, sizeof(fullname), "maps/%s.bsp", model);

--- a/src/client/refresh/gl4/gl4_model.c
+++ b/src/client/refresh/gl4/gl4_model.c
@@ -453,6 +453,8 @@ GL4_BeginRegistration(const char *model)
 	registration_sequence++;
 	r_oldviewcluster = -1; /* force markleafs */
 
+	R_PicPathCacheClean();
+
 	gl4state.currentlightmap = -1;
 
 	Com_sprintf(fullname, sizeof(fullname), "maps/%s.bsp", model);

--- a/src/client/refresh/soft/sw_model.c
+++ b/src/client/refresh/soft/sw_model.c
@@ -458,6 +458,8 @@ RE_BeginRegistration(const char *model)
 	registration_sequence++;
 	r_oldviewcluster = -1; /* force markleafs */
 
+	R_PicPathCacheClean();
+
 	Com_sprintf(fullname, sizeof(fullname), "maps/%s.bsp", model);
 
 	D_FlushCaches ();

--- a/src/client/refresh/vk/vk_model.c
+++ b/src/client/refresh/vk/vk_model.c
@@ -449,6 +449,8 @@ RE_BeginRegistration(const char *model)
 	registration_sequence++;
 	r_oldviewcluster = -1; /* force markleafs */
 
+	R_PicPathCacheClean();
+
 	Com_sprintf(fullname, sizeof(fullname), "maps/%s.bsp", model);
 
 	/* explicitly free the old map if different


### PR DESCRIPTION
A miss now lands in the ignore table, so R_FindPic returns early instead of retrying the four prefixes every frame. Both tables are cleared per map, so a pic arriving in a pak downloaded during precache still resolves.